### PR TITLE
feat: support prefixed Graz storage keys

### DIFF
--- a/.changeset/tidy-cups-provide.md
+++ b/.changeset/tidy-cups-provide.md
@@ -1,0 +1,5 @@
+---
+"graz": minor
+---
+
+Add a `prefixStorageKey` provider option for isolating Graz's persisted local and session storage keys by app.

--- a/example/next/pages/_app.tsx
+++ b/example/next/pages/_app.tsx
@@ -16,6 +16,7 @@ const CustomApp: NextPage<AppProps> = ({ Component, pageProps }) => {
         <GrazProvider
           grazOptions={{
             chains,
+            prefixStorageKey: 'next',
             onReconnectFailed: () => {
               console.log("reconnect failed");
             },

--- a/example/playground/src/app/providers.tsx
+++ b/example/playground/src/app/providers.tsx
@@ -42,6 +42,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           grazOptions={{
             chains,
             autoReconnect: true,
+            prefixStorageKey: "playground",
             paraConfig,
             walletConnect: {
               options: {

--- a/packages/graz/src/__tests__/setup.ts
+++ b/packages/graz/src/__tests__/setup.ts
@@ -1,6 +1,8 @@
 import { beforeEach, vi } from "vitest";
 
 import {
+  GRAZ_INTERNAL_STORAGE_KEY,
+  GRAZ_SESSION_STORAGE_KEY,
   grazInternalDefaultValues,
   grazSessionDefaultValues,
   useGrazInternalStore,
@@ -31,6 +33,8 @@ if (!window.matchMedia) {
 // Reset mocks before each test
 beforeEach(() => {
   vi.clearAllMocks();
+  useGrazInternalStore.persist.setOptions({ name: GRAZ_INTERNAL_STORAGE_KEY });
+  useGrazSessionStore.persist.setOptions({ name: GRAZ_SESSION_STORAGE_KEY });
   window.localStorage.clear();
   window.sessionStorage.clear();
   useGrazInternalStore.setState({ ...grazInternalDefaultValues }, true);

--- a/packages/graz/src/actions/__tests__/configure.test.ts
+++ b/packages/graz/src/actions/__tests__/configure.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { makeChainInfo } from "../../__tests__/fixtures";
-import { useGrazInternalStore } from "../../store";
+import {
+  GRAZ_INTERNAL_STORAGE_KEY,
+  GRAZ_SESSION_STORAGE_KEY,
+  useGrazInternalStore,
+  useGrazSessionStore,
+} from "../../store";
 import { LogLevel } from "../../types/logger";
 import { WalletType } from "../../types/wallet";
 import { configureGraz } from "../configure";
@@ -49,5 +54,91 @@ describe("configureGraz", () => {
     });
 
     expect(useGrazInternalStore.getState().chains).toEqual([provider, providerOverride]);
+  });
+
+  it("prefixes internal and session storage keys before rehydrating persisted state", () => {
+    const provider = makeChainInfo("cosmoshub-4");
+    const persisted = makeChainInfo("osmosis-1");
+
+    window.localStorage.setItem(
+      `playground-${GRAZ_INTERNAL_STORAGE_KEY}`,
+      JSON.stringify({
+        state: {
+          chains: [persisted],
+          recentChainIds: [persisted.chainId],
+          walletType: WalletType.LEAP,
+          _reconnect: true,
+          _reconnectConnector: WalletType.LEAP,
+        },
+        version: 3,
+      }),
+    );
+    window.sessionStorage.setItem(
+      `playground-${GRAZ_SESSION_STORAGE_KEY}`,
+      JSON.stringify({
+        state: {
+          accounts: {
+            [persisted.chainId]: {
+              algo: "secp256k1",
+              address: "osmo1address",
+              bech32Address: "osmo1address",
+              isNanoLedger: false,
+              name: "Osmosis",
+              pubKey: new Uint8Array(),
+            },
+          },
+          activeChainIds: [persisted.chainId],
+          lastPing: 123,
+          status: "connected",
+        },
+        version: 2,
+      }),
+    );
+
+    configureGraz({
+      chains: [provider],
+      prefixStorageKey: "playground",
+    });
+
+    expect(useGrazInternalStore.getState()).toMatchObject({
+      chains: [provider, persisted],
+      recentChainIds: [persisted.chainId],
+      walletType: WalletType.LEAP,
+      _reconnect: true,
+      _reconnectConnector: WalletType.LEAP,
+    });
+    expect(useGrazSessionStore.getState()).toMatchObject({
+      activeChainIds: [persisted.chainId],
+      lastPing: 123,
+      status: "connected",
+    });
+  });
+
+  it("uses default storage keys when no prefix is configured", () => {
+    const chain = makeChainInfo();
+
+    window.localStorage.setItem(
+      `playground-${GRAZ_INTERNAL_STORAGE_KEY}`,
+      JSON.stringify({
+        state: {
+          chains: [makeChainInfo("osmosis-1")],
+          recentChainIds: ["osmosis-1"],
+          walletType: WalletType.LEAP,
+          _reconnect: true,
+          _reconnectConnector: WalletType.LEAP,
+        },
+        version: 3,
+      }),
+    );
+
+    configureGraz({ chains: [chain] });
+
+    expect(useGrazInternalStore.getState()).toMatchObject({
+      chains: [chain],
+      recentChainIds: null,
+      walletType: WalletType.KEPLR,
+      _reconnect: true,
+      _reconnectConnector: null,
+    });
   });
 });

--- a/packages/graz/src/actions/configure.ts
+++ b/packages/graz/src/actions/configure.ts
@@ -1,7 +1,7 @@
 import type { ChainInfo } from "@keplr-wallet/types";
 
 import type { CapsuleConfig, ChainConfig, GrazInternalStore, IframeOptions } from "../store";
-import { useGrazInternalStore } from "../store";
+import { useGrazInternalStore, useGrazSessionStore } from "../store";
 import type { WalletType } from "../types/wallet";
 
 export interface ConfigureGrazArgs {
@@ -26,9 +26,22 @@ export interface ConfigureGrazArgs {
    * Options to enable iframe wallet connection.
    */
   iframeOptions?: IframeOptions;
+  prefixStorageKey?: string;
 }
 
 export const configureGraz = (args: ConfigureGrazArgs): ConfigureGrazArgs => {
+  if (args.prefixStorageKey) {
+    useGrazInternalStore.persist.setOptions({
+      name: `${args.prefixStorageKey}-graz-internal`,
+    });
+    useGrazSessionStore.persist.setOptions({
+      name: `${args.prefixStorageKey}-graz-session`,
+    });
+    useGrazInternalStore.persist.rehydrate();
+    useGrazSessionStore.persist.rehydrate();
+    localStorage.removeItem("graz-internal");
+    sessionStorage.removeItem("graz-session");
+  }
   useGrazInternalStore.setState((prev) => ({
     iframeOptions: args.iframeOptions || prev.iframeOptions,
     walletConnect: args.walletConnect || prev.walletConnect,

--- a/packages/graz/src/actions/configure.ts
+++ b/packages/graz/src/actions/configure.ts
@@ -1,7 +1,12 @@
 import type { ChainInfo } from "@keplr-wallet/types";
 
 import type { ChainConfig, GrazInternalStore, IframeOptions } from "../store";
-import { useGrazInternalStore } from "../store";
+import {
+  GRAZ_INTERNAL_STORAGE_KEY,
+  GRAZ_SESSION_STORAGE_KEY,
+  useGrazInternalStore,
+  useGrazSessionStore,
+} from "../store";
 import { LogCategory, type LogLevel } from "../types/logger";
 import type { WalletType } from "../types/wallet";
 import { configureLogger } from "../utils/logger";
@@ -29,6 +34,10 @@ export interface ConfigureGrazArgs {
    * Options to enable iframe wallet connection.
    */
   iframeOptions?: IframeOptions;
+  /**
+   * Prefix persisted Graz storage keys, useful when multiple Graz apps share one origin.
+   */
+  prefixStorageKey?: string;
   pingInteval?: number;
   /**
    * Logger configuration
@@ -40,7 +49,25 @@ export interface ConfigureGrazArgs {
   };
 }
 
+const prefixedStorageKey = (key: string, prefix?: string) => (prefix ? `${prefix}-${key}` : key);
+
+const configurePersistedStorageKeys = (prefixStorageKey?: string) => {
+  useGrazInternalStore.persist.setOptions({
+    name: prefixedStorageKey(GRAZ_INTERNAL_STORAGE_KEY, prefixStorageKey),
+  });
+  useGrazSessionStore.persist.setOptions({
+    name: prefixedStorageKey(GRAZ_SESSION_STORAGE_KEY, prefixStorageKey),
+  });
+
+  if (typeof window !== "undefined") {
+    useGrazInternalStore.persist.rehydrate();
+    useGrazSessionStore.persist.rehydrate();
+  }
+};
+
 export const configureGraz = (args: ConfigureGrazArgs): ConfigureGrazArgs => {
+  configurePersistedStorageKeys(args.prefixStorageKey);
+
   // Configure logger - only enable if explicitly provided
   configureLogger({
     enabled: args.logger?.enabled ?? false,

--- a/packages/graz/src/store/index.ts
+++ b/packages/graz/src/store/index.ts
@@ -115,6 +115,9 @@ export const grazInternalDefaultValues: GrazInternalStore = {
   _reconnectConnector: null,
 };
 
+export const GRAZ_INTERNAL_STORAGE_KEY = "graz-internal";
+export const GRAZ_SESSION_STORAGE_KEY = "graz-session";
+
 export const grazSessionDefaultValues: GrazSessionStore = {
   accounts: null,
   activeChainIds: null,
@@ -125,7 +128,7 @@ export const grazSessionDefaultValues: GrazSessionStore = {
 };
 
 const sessionOptions: PersistOptions<GrazSessionStore, GrazSessionPersistedStore> = {
-  name: "graz-session",
+  name: GRAZ_SESSION_STORAGE_KEY,
   version: 2,
   partialize: (x) => ({
     accounts: x.accounts,
@@ -137,7 +140,7 @@ const sessionOptions: PersistOptions<GrazSessionStore, GrazSessionPersistedStore
 };
 
 const persistOptions: PersistOptions<GrazInternalStore, GrazInternalPersistedStore> = {
-  name: "graz-internal",
+  name: GRAZ_INTERNAL_STORAGE_KEY,
   partialize: (x) => ({
     recentChainIds: x.recentChainIds,
     _reconnect: x._reconnect,


### PR DESCRIPTION
## Summary
- add `prefixStorageKey` to `GrazProvider`/`configureGraz` so apps can namespace Graz local/session storage keys on shared origins
- rehydrate both internal and session stores from the selected namespace before applying provider configuration
- document usage in the playground provider and add a changeset

## Verification
- `pnpm --dir packages/graz type-check`
- `node ./node_modules/vitest/vitest.mjs run packages/graz/src/actions/__tests__/configure.test.ts --root packages/graz --pool=threads --maxWorkers 1`