### PR TITLE
fix: use `getKeys` instead of `getKey` for Leap Dapp Browser

### DIFF
--- a/.changeset/sweet-candies-learn.md
+++ b/.changeset/sweet-candies-learn.md
@@ -1,0 +1,5 @@
+---
+"graz": patch
+---
+
+We have updated from `getKey` to `getKeys` for accounts fetching in leap dapp browser as that is much faster.

--- a/packages/graz/package.json
+++ b/packages/graz/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graz",
   "description": "React hooks for Cosmos",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Griko Nibras <griko@strange.love>",
   "repository": "https://github.com/graz-sh/graz.git",
   "homepage": "https://github.com/graz-sh/graz",

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -6,7 +6,7 @@ import { grazSessionDefaultValues, useGrazInternalStore, useGrazSessionStore } f
 import type { Maybe } from "../types/core";
 import type { Key, WalletType } from "../types/wallet";
 import type { ChainId } from "../utils/multi-chain";
-import { checkWallet, getWallet, isCapsule, isLeapSnaps, isWalletConnect } from "./wallet";
+import { checkWallet, getWallet, isCapsule, isLeapDappBrowser, isLeapSnaps, isWalletConnect } from "./wallet";
 
 export type ConnectArgs = Maybe<{
   chainId: ChainId;
@@ -99,12 +99,21 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
     }
     if (!isWalletConnect(currentWalletType)) {
       let resultAccounts: Record<string, Key> = {};
-      if (chainIds.length > 1 && isLeapSnaps(currentWalletType)) {
-        const accounts: Record<string, Key> = {};
-        for await (const chainId of chainIds) {
-          accounts[chainId] = await wallet.getKey(chainId);
+      if (chainIds.length > 1) {
+        if (isLeapSnaps(currentWalletType)) {
+          const accounts: Record<string, Key> = {};
+          for await (const chainId of chainIds) {
+            accounts[chainId] = await wallet.getKey(chainId);
+          }
+          resultAccounts = accounts;
+        } else if (isLeapDappBrowser() && wallet.getKeys) {
+          const allAccounts = await wallet.getKeys(chainIds);
+          chainIds.forEach((chainId, index) => {
+            if (allAccounts[index]) {
+              resultAccounts[chainId] = allAccounts[index];
+            }
+          });
         }
-        resultAccounts = accounts;
       } else {
         resultAccounts = Object.fromEntries(
           await Promise.all(

--- a/packages/graz/src/actions/wallet/index.ts
+++ b/packages/graz/src/actions/wallet/index.ts
@@ -139,6 +139,11 @@ export const isLeapSnaps = (type: WalletType): boolean => {
   return type === WalletType.METAMASK_SNAP_LEAP;
 };
 
+export const isLeapDappBrowser = (): boolean => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  return Boolean(navigator?.userAgent) && /LeapCosmos/i.test(navigator.userAgent);
+};
+
 export const isWalletConnect = (type: WalletType): boolean => {
   return (
     type === WalletType.WALLETCONNECT ||

--- a/packages/graz/src/types/wallet.ts
+++ b/packages/graz/src/types/wallet.ts
@@ -60,6 +60,7 @@ export type Wallet = Pick<
   setDefaultOptions?: (options: KeplrIntereactionOptions) => void;
   onAfterLoginSuccessful?: () => Promise<void>;
   getKey: (chainId: string) => Promise<Key>;
+  getKeys?: (chainIds: string[]) => Promise<(Key | undefined)[]>;
   signEthereum?: Keplr["signEthereum"];
   experimentalSignEIP712CosmosTx_v0?: Keplr["experimentalSignEIP712CosmosTx_v0"];
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR ...

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

- [x] Changed method to get Accounts from Leap Dapp Browser to use `getKeys` as it's faster for multiple chains.

## Screenshots

...

## Testing

- Open page ...
- Click ...
- Make sure that ...

## Links/References

- ...
- ...
- ...

## Notes

- ...
- ...
- ...
