### PR TITLE
Remove integration coverage changeset

### DIFF
--- a/.changeset/fresh-lamps-exercise.md
+++ b/.changeset/fresh-lamps-exercise.md
@@ -1,5 +1,0 @@
----
-"graz": minor
----
-
-Add automated library coverage and browser integration testing for Graz, including Vitest coverage across core actions, hooks, providers, wallet adapters, and utilities plus a Playwright harness with an injected Keplr-compatible wallet for connection, signer, and client flows.


### PR DESCRIPTION
## Summary
- remove the integration coverage changeset from dev
- keep the automated testing work unreleased because the modernization patch was already published

## Validation
- diff only removes `.changeset/fresh-lamps-exercise.md`

Refs #235