### PR TITLE
[codex] Fix useChainInfo docs label

### DIFF
--- a/docs/docs/hooks/useChainInfo.md
+++ b/docs/docs/hooks/useChainInfo.md
@@ -1,4 +1,4 @@
-# useActiveChains
+# useChainInfo
 
 hook to retrieve `ChainInfo` object from `GrazProvider` with given `chainId`
 


### PR DESCRIPTION
## Summary
- Correct the `useChainInfo` docs page heading so the sidebar/page label no longer shows `useActiveChains`.

Closes #203

## Validation
- `pnpm project:docs build`
  - Passes; Docusaurus still reports existing warnings for deprecated broken-link config and two unrelated broken anchors.