### PR TITLE
[codex] Support undefined query hook arguments

### DIFF
--- a/.changeset/calm-query-hooks.md
+++ b/.changeset/calm-query-hooks.md
@@ -1,0 +1,5 @@
+---
+"graz": patch
+---
+
+Support query hooks with required argument values that may be undefined while inputs are still loading.

--- a/packages/graz/src/hooks/__tests__/account-balances.test.tsx
+++ b/packages/graz/src/hooks/__tests__/account-balances.test.tsx
@@ -7,7 +7,7 @@ vi.mock("../clients", () => ({
 }));
 
 import { makeChainInfo } from "../../__tests__/fixtures";
-import { createQueryWrapper, renderHook } from "../../__tests__/react";
+import { createQueryWrapper, flushReact, renderHook } from "../../__tests__/react";
 import { useGrazInternalStore } from "../../store";
 import { useBalance, useBalances, useBalanceStaked } from "../account";
 
@@ -84,6 +84,52 @@ describe("balance hooks", () => {
       expect(rendered.result.isSuccess).toBe(true);
     });
     expect(rendered.result.data).toBeUndefined();
+    rendered.unmount();
+  });
+
+  it("keeps balance queries idle while required arguments are undefined", async () => {
+    const { wrapper } = createQueryWrapper();
+    const chain = makeChainInfo();
+    const client = {
+      getAllBalances: vi.fn(),
+      getBalance: vi.fn(),
+      getBalanceStaked: vi.fn(),
+    };
+    useGrazInternalStore.setState({ chains: [chain] });
+    useStargateClientMock.mockReturnValue({
+      data: {
+        [chain.chainId]: client,
+      },
+    });
+
+    const rendered = renderHook(
+      () => ({
+        balance: useBalance({
+          bech32Address: "cosmos1address",
+          chainId: chain.chainId,
+          denom: undefined,
+        }),
+        balances: useBalances({
+          bech32Address: undefined,
+          chainId: chain.chainId,
+        }),
+        staked: useBalanceStaked({
+          bech32Address: "cosmos1address",
+          chainId: undefined,
+        }),
+      }),
+      { wrapper },
+    );
+    await flushReact();
+
+    expect(rendered.result.balance.fetchStatus).toBe("idle");
+    expect(rendered.result.balances.fetchStatus).toBe("idle");
+    expect(rendered.result.staked.fetchStatus).toBe("idle");
+    expect(client.getAllBalances).not.toHaveBeenCalled();
+    expect(client.getBalance).not.toHaveBeenCalled();
+    expect(client.getBalanceStaked).not.toHaveBeenCalled();
+    expect(useStargateClientMock).toHaveBeenCalledWith({ chainId: [chain.chainId], enabled: false });
+    expect(useStargateClientMock).toHaveBeenCalledWith({ chainId: [], enabled: false });
     rendered.unmount();
   });
 });

--- a/packages/graz/src/hooks/__tests__/chains.test.tsx
+++ b/packages/graz/src/hooks/__tests__/chains.test.tsx
@@ -80,6 +80,23 @@ describe("chain hooks", () => {
     rendered.unmount();
   });
 
+  it("keeps active chain currency query idle while denom is undefined", async () => {
+    const { wrapper } = createQueryWrapper();
+    const cosmoshub = makeChainInfo();
+    useGrazInternalStore.setState({ chains: [cosmoshub] });
+    useGrazSessionStore.setState({ activeChainIds: [cosmoshub.chainId] });
+
+    const rendered = renderHook(
+      () => useActiveChainCurrency({ denom: undefined }),
+      { wrapper },
+    );
+    await flushReact();
+
+    expect(rendered.result.data).toBeUndefined();
+    expect(rendered.result.fetchStatus).toBe("idle");
+    rendered.unmount();
+  });
+
   it("queries staking validators when a query client is provided", async () => {
     const { wrapper } = createQueryWrapper();
     const validatorsResponse = {

--- a/packages/graz/src/hooks/account.ts
+++ b/packages/graz/src/hooks/account.ts
@@ -1,4 +1,5 @@
 import type { Coin } from "@cosmjs/proto-signing";
+import type { StargateClient } from "@cosmjs/stargate";
 import type { Key } from "@keplr-wallet/types";
 import { useMutation, useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
@@ -37,6 +38,15 @@ export interface UseAccountResult<TChainIds extends readonly string[] | undefine
   status: string;
   walletType?: WalletType;
 }
+
+type UseBalancesArgs = {
+  bech32Address: string | undefined;
+  chainId: string | undefined;
+} & QueryConfig;
+
+type UseBalanceArgs = UseBalancesArgs & {
+  denom: string | undefined;
+};
 
 /**
  * graz query hook to retrieve account data with optional arguments to invoke
@@ -160,17 +170,21 @@ export function useAccount<const TChainIds extends readonly string[] | undefined
  * ```
  */
 export const useBalances = (
-  args: { bech32Address: string; chainId: string } & QueryConfig,
+  args: UseBalancesArgs,
 ): UseQueryResult<Coin[], unknown> => {
-  const chains = useChainsFromArgs({ chainId: [args.chainId] });
-  const chain = chains[0];
+  const chains = useGrazInternalStore((x) => x.chains);
+  const chain = args.chainId ? chains?.find((x) => x.chainId === args.chainId) : undefined;
+  const queryEnabled =
+    Boolean(args.chainId) &&
+    Boolean(args.bech32Address) &&
+    (args.enabled === undefined ? true : args.enabled);
 
   const { data: clients } = useStargateClient({
-    chainId: [args.chainId] as readonly string[],
-    enabled: args.enabled === undefined ? true : args.enabled,
+    chainId: args.chainId ? [args.chainId] : [],
+    enabled: queryEnabled,
   });
 
-  const client = clients?.[args.chainId];
+  const client = args.chainId ? (clients as Record<string, StargateClient> | undefined)?.[args.chainId] : undefined;
 
   const queryKey = useMemo(
     () => ["USE_ALL_BALANCES", client, args.chainId, args.bech32Address],
@@ -180,6 +194,9 @@ export const useBalances = (
   return useQuery({
     queryKey,
     queryFn: async () => {
+      if (!args.chainId || !args.bech32Address) {
+        throw new Error("chainId or bech32Address undefined");
+      }
       if (!client) {
         throw new Error(`Client is not ready for ${args.chainId}`);
       }
@@ -189,7 +206,7 @@ export const useBalances = (
       const balances = await client.getAllBalances(args.bech32Address);
       return balances as Coin[];
     },
-    enabled: Boolean(client) && Boolean(chain) && (args.enabled === undefined ? true : args.enabled),
+    enabled: Boolean(client) && Boolean(chain) && queryEnabled,
     refetchOnMount: false,
     refetchOnReconnect: true,
     refetchOnWindowFocus: false,
@@ -216,17 +233,22 @@ export const useBalances = (
  * ```
  */
 export const useBalance = (
-  args: { bech32Address: string; chainId: string; denom: string } & QueryConfig,
+  args: UseBalanceArgs,
 ): UseQueryResult<Coin | undefined, unknown> => {
-  const chains = useChainsFromArgs({ chainId: [args.chainId] });
-  const chain = chains[0];
+  const chains = useGrazInternalStore((x) => x.chains);
+  const chain = args.chainId ? chains?.find((x) => x.chainId === args.chainId) : undefined;
+  const queryEnabled =
+    Boolean(args.chainId) &&
+    Boolean(args.bech32Address) &&
+    Boolean(args.denom) &&
+    (args.enabled === undefined ? true : args.enabled);
 
   const { data: clients } = useStargateClient({
-    chainId: [args.chainId] as readonly string[],
-    enabled: args.enabled === undefined ? true : args.enabled,
+    chainId: args.chainId ? [args.chainId] : [],
+    enabled: queryEnabled,
   });
 
-  const client = clients?.[args.chainId];
+  const client = args.chainId ? (clients as Record<string, StargateClient> | undefined)?.[args.chainId] : undefined;
 
   const queryKey = useMemo(
     () => ["USE_BALANCE", client, args.chainId, args.bech32Address, args.denom],
@@ -236,6 +258,9 @@ export const useBalance = (
   return useQuery<Coin | null, unknown, Coin | undefined>({
     queryKey,
     queryFn: async () => {
+      if (!args.chainId || !args.bech32Address || !args.denom) {
+        throw new Error("chainId, bech32Address, or denom undefined");
+      }
       if (!client) {
         throw new Error(`Client is not ready for ${args.chainId}`);
       }
@@ -246,7 +271,7 @@ export const useBalance = (
       return balance.amount === "0" ? null : balance;
     },
     select: (balance) => balance ?? undefined,
-    enabled: Boolean(client) && Boolean(chain) && (args.enabled === undefined ? true : args.enabled),
+    enabled: Boolean(client) && Boolean(chain) && queryEnabled,
     refetchOnMount: false,
     refetchOnReconnect: true,
     refetchOnWindowFocus: false,
@@ -478,17 +503,21 @@ export function useOfflineSigners<const TChainIds extends readonly string[] | un
  * ```
  */
 export const useBalanceStaked = (
-  args: { bech32Address: string; chainId: string } & QueryConfig,
+  args: UseBalancesArgs,
 ): UseQueryResult<Coin | null, unknown> => {
-  const chains = useChainsFromArgs({ chainId: [args.chainId] });
-  const chain = chains[0];
+  const chains = useGrazInternalStore((x) => x.chains);
+  const chain = args.chainId ? chains?.find((x) => x.chainId === args.chainId) : undefined;
+  const queryEnabled =
+    Boolean(args.chainId) &&
+    Boolean(args.bech32Address) &&
+    (args.enabled === undefined ? true : args.enabled);
 
   const { data: clients } = useStargateClient({
-    chainId: [args.chainId] as readonly string[],
-    enabled: args.enabled === undefined ? true : args.enabled,
+    chainId: args.chainId ? [args.chainId] : [],
+    enabled: queryEnabled,
   });
 
-  const client = clients?.[args.chainId];
+  const client = args.chainId ? (clients as Record<string, StargateClient> | undefined)?.[args.chainId] : undefined;
 
   const queryKey = useMemo(
     () => ["USE_BALANCE_STAKED", client, args.chainId, args.bech32Address],
@@ -498,6 +527,9 @@ export const useBalanceStaked = (
   return useQuery({
     queryKey,
     queryFn: async () => {
+      if (!args.chainId || !args.bech32Address) {
+        throw new Error("chainId or bech32Address undefined");
+      }
       if (!client) {
         throw new Error(`Client is not ready for ${args.chainId}`);
       }
@@ -507,7 +539,7 @@ export const useBalanceStaked = (
       const balance = await client.getBalanceStaked(args.bech32Address);
       return balance;
     },
-    enabled: Boolean(client) && Boolean(chain) && (args.enabled === undefined ? true : args.enabled),
+    enabled: Boolean(client) && Boolean(chain) && queryEnabled,
     refetchOnMount: false,
     refetchOnReconnect: true,
     refetchOnWindowFocus: false,

--- a/packages/graz/src/hooks/chains.ts
+++ b/packages/graz/src/hooks/chains.ts
@@ -99,13 +99,22 @@ export const useChainInfos = ({ chainId }: { chainId?: string[] } = {}) => {
  * const { data: currency, ... } = useActiveChainCurrency({denom: "juno"});
  * ```
  */
-export const useActiveChainCurrency = ({ denom }: { denom: string }): UseQueryResult<AppCurrency | undefined> => {
+export const useActiveChainCurrency = ({
+  denom,
+}: {
+  denom: string | undefined;
+}): UseQueryResult<AppCurrency | undefined> => {
   const chains = useActiveChains();
   const queryKey = ["USE_ACTIVE_CHAIN_CURRENCY", denom];
-  const query = useQuery({
+  const query = useQuery<AppCurrency | null, Error, AppCurrency | undefined>({
     queryKey,
-    queryFn: ({ queryKey: [, _denom] }) =>
-      chains?.find((c) => c.currencies.find((x) => x.coinMinimalDenom === _denom))?.currencies.find((x) => x),
+    queryFn: () => {
+      if (!denom) throw new Error("denom undefined");
+      if (!chains) throw new Error("No active chains found");
+      return chains.flatMap((chain) => chain.currencies).find((currency) => currency.coinMinimalDenom === denom) ?? null;
+    },
+    select: (currency) => currency ?? undefined,
+    enabled: Boolean(denom) && Boolean(chains?.length),
   });
   return query;
 };


### PR DESCRIPTION
## Summary
- Allow balance query hooks and `useActiveChainCurrency` to receive required-but-not-yet-loaded argument values as `undefined`.
- Keep those queries disabled until the required values are present, instead of accidentally treating a missing `chainId` as all configured chains.
- Add regression coverage for idle queries when required values are unavailable.

Closes #135

## Validation
- `pnpm graz test -- account-balances chains`
- `pnpm graz type-check`
- `pnpm graz build`
- `pnpm graz lint` (passes with existing warnings)