### PR TITLE
[codex] Select MetaMask provider for Snap wallets

### DIFF
--- a/.changeset/brave-snaps-search.md
+++ b/.changeset/brave-snaps-search.md
@@ -1,0 +1,5 @@
+---
+"graz": patch
+---
+
+Select the MetaMask provider for Snap wallets when another extension controls window.ethereum.

--- a/packages/graz/src/actions/wallet/__tests__/metamask-snap.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/metamask-snap.test.ts
@@ -122,6 +122,35 @@ describe("MetaMask Snap adapters", () => {
     expect(cosmosSnapClient.deleteChain).toHaveBeenCalledWith(chain.chainId);
   });
 
+  it("selects MetaMask for the Cosmos Snap adapter when another wallet owns window.ethereum", async () => {
+    const phantom = {
+      isPhantom: true,
+      request: vi.fn(async ({ method }: EthereumRequest) => {
+        if (method === "web3_clientVersion") return "Phantom/v1.0.0";
+        return undefined;
+      }),
+    };
+    const metamask = {
+      isMetaMask: true,
+      request: vi.fn(async ({ method }: EthereumRequest) => {
+        if (method === "web3_clientVersion") return "MetaMask/v11.0.0";
+        return undefined;
+      }),
+    };
+    setWindowValue("ethereum", {
+      ...phantom,
+      providers: [phantom, metamask],
+    });
+    isSnapInstalled.mockResolvedValue(true);
+
+    const wallet = getMetamaskSnapCosmos();
+
+    await expect(wallet.init?.()).resolves.toBe(true);
+    expect(window.ethereum).toBe(metamask);
+    expect(metamask.request).toHaveBeenCalledWith({ method: "web3_clientVersion" });
+    expect(phantom.request).not.toHaveBeenCalled();
+  });
+
   it("initializes and delegates the Leap MetaMask Snap adapter", async () => {
     const chain = makeChainInfo();
     const requests: EthereumRequest[] = [];
@@ -217,5 +246,41 @@ describe("MetaMask Snap adapters", () => {
     });
     await expect(wallet.experimentalSuggestChain(chain)).resolves.toBeUndefined();
     expect(requests.some((request) => request.params?.request?.method === "suggestChain")).toBe(true);
+  });
+
+  it("selects MetaMask for the Leap Snap adapter when another wallet owns window.ethereum", async () => {
+    const requests: EthereumRequest[] = [];
+    const phantom = {
+      isPhantom: true,
+      request: vi.fn(async ({ method }: EthereumRequest) => {
+        if (method === "web3_clientVersion") return "Phantom/v1.0.0";
+        return undefined;
+      }),
+    };
+    const metamask = {
+      isMetaMask: true,
+      request: vi.fn(async (request: EthereumRequest) => {
+        requests.push(request);
+        if (request.method === "web3_clientVersion") return "MetaMask/v11.0.0";
+        if (request.method === "wallet_getSnaps") return {};
+        if (request.method === "wallet_requestSnaps") return null;
+        return undefined;
+      }),
+    };
+    setWindowValue("ethereum", {
+      ...phantom,
+      providers: [phantom, metamask],
+    });
+
+    const wallet = getMetamaskSnap({ id: "npm:@leapwallet/metamask-cosmos-snap" });
+
+    await expect(wallet.init?.()).resolves.toBe(true);
+    expect(window.ethereum).toBe(metamask);
+    expect(requests.map((request) => request.method)).toEqual([
+      "web3_clientVersion",
+      "wallet_getSnaps",
+      "wallet_requestSnaps",
+    ]);
+    expect(phantom.request).not.toHaveBeenCalled();
   });
 });

--- a/packages/graz/src/actions/wallet/cosmos-metamask-snap/index.ts
+++ b/packages/graz/src/actions/wallet/cosmos-metamask-snap/index.ts
@@ -3,11 +3,12 @@ import { CosmosSnap, installSnap, isSnapInstalled } from "@cosmsnap/snapper";
 import { useGrazInternalStore } from "../../../store";
 import type { KnownKeys, Wallet } from "../../../types/wallet";
 import type { ChainId } from "../../../utils/multi-chain";
+import { selectMetamaskProvider } from "../metamask";
 
 const metamaskSnapCosmosKeysMap: KnownKeys = {};
 
 export const getMetamaskSnapCosmos = (): Wallet => {
-  const ethereum = window.ethereum;
+  const ethereum = selectMetamaskProvider();
   let cosmos = window.cosmos;
   if (ethereum) {
     const init = async () => {

--- a/packages/graz/src/actions/wallet/leap-metamask-snap/index.ts
+++ b/packages/graz/src/actions/wallet/leap-metamask-snap/index.ts
@@ -5,6 +5,7 @@ import Long from "long";
 import { useGrazInternalStore } from "../../../store";
 import type { Key, KnownKeys, SignAminoParams, SignDirectParams, Wallet } from "../../../types/wallet";
 import type { ChainId } from "../../../utils/multi-chain";
+import { selectMetamaskProvider } from "../metamask";
 import type { GetSnapsResponse, Snap } from "./types";
 
 export interface GetMetamaskSnap {
@@ -32,7 +33,7 @@ const metamaskSnapLeapKeysMap: KnownKeys = {};
  *
  */
 export const getMetamaskSnap = (params?: GetMetamaskSnap): Wallet => {
-  const ethereum = window.ethereum;
+  const ethereum = selectMetamaskProvider();
 
   if (ethereum && params) {
     const getSnaps = async (): Promise<GetSnapsResponse> => {

--- a/packages/graz/src/actions/wallet/metamask.ts
+++ b/packages/graz/src/actions/wallet/metamask.ts
@@ -1,0 +1,24 @@
+import type { MetaMaskInpageProvider } from "@metamask/providers";
+
+type InjectedEthereumProvider = MetaMaskInpageProvider & {
+  isMetaMask?: boolean;
+  providers?: InjectedEthereumProvider[];
+};
+
+const isMetamaskProvider = (provider: unknown): boolean => {
+  if (!provider || typeof provider !== "object") return false;
+  const candidate = provider as InjectedEthereumProvider;
+  return Boolean(candidate.isMetaMask && typeof candidate.request === "function");
+};
+
+export const selectMetamaskProvider = (): MetaMaskInpageProvider | undefined => {
+  const ethereum = window.ethereum as InjectedEthereumProvider | undefined;
+  if (!ethereum) return undefined;
+
+  const metamask = isMetamaskProvider(ethereum) ? ethereum : ethereum.providers?.find(isMetamaskProvider);
+  if (metamask && window.ethereum !== metamask) {
+    window.ethereum = metamask;
+  }
+
+  return metamask ?? ethereum;
+};


### PR DESCRIPTION
## Summary
- Select the MetaMask provider from `window.ethereum.providers` when another injected wallet owns `window.ethereum`.
- Apply the provider selection to both Cosmos Snap and Leap MetaMask Snap adapters.
- Add regression coverage for Phantom-first provider injection.
- Add a patch changeset for the package fix.

Closes #152

## Validation
- `pnpm graz test -- metamask-snap`
- `pnpm graz type-check`
- `pnpm graz build`
- `pnpm graz lint` (passes with existing warnings)
- `pnpm changeset status --since origin/dev`