### PR TITLE
[codex] add arbitrary message signing hooks

### DIFF
--- a/.changeset/honest-signatures-drum.md
+++ b/.changeset/honest-signatures-drum.md
@@ -1,0 +1,5 @@
+---
+"graz": patch
+---
+
+Add arbitrary message signing and verification actions and hooks.

--- a/docs/docs/hooks/useSignArbitrary.md
+++ b/docs/docs/hooks/useSignArbitrary.md
@@ -1,0 +1,130 @@
+# useSignArbitrary
+
+Mutation hook to sign arbitrary messages with the active wallet's ADR-36-compatible signing API.
+
+Use this for authentication flows where your app asks a connected wallet address to sign a nonce, challenge, or other plain message. Wallets that do not expose `signArbitrary` reject with an explicit unsupported-method error.
+
+## Usage
+
+### Basic Example
+
+```tsx
+import { useAccount, useSignArbitrary } from "graz";
+
+function SignInButton() {
+  const chainId = "cosmoshub-4";
+  const { data: accounts } = useAccount({ chainId: [chainId] });
+  const { signArbitraryAsync, isPending } = useSignArbitrary();
+
+  const account = accounts?.[chainId];
+
+  async function handleSignIn() {
+    if (!account) return;
+
+    const signature = await signArbitraryAsync({
+      chainId,
+      signerAddress: account.bech32Address,
+      data: "Sign in to example.com with nonce 12345",
+    });
+
+    console.log("Signature:", signature);
+  }
+
+  return (
+    <button onClick={handleSignIn} disabled={!account || isPending}>
+      {isPending ? "Signing..." : "Sign in"}
+    </button>
+  );
+}
+```
+
+### With Event Handlers
+
+```tsx
+import { useSignArbitrary } from "graz";
+
+function SignMessage() {
+  const { signArbitrary } = useSignArbitrary({
+    onSuccess: (signature) => {
+      console.log("Message signed", signature);
+    },
+    onError: (error) => {
+      console.error("Signing failed", error);
+    },
+    onLoading: (args) => {
+      console.log("Signing message for", args.signerAddress);
+    },
+  });
+
+  // ... call signArbitrary({ chainId, signerAddress, data })
+}
+```
+
+### Action Usage
+
+You can call the framework-agnostic action directly outside React components:
+
+```ts
+import { signArbitrary } from "graz";
+
+const signature = await signArbitrary({
+  chainId: "cosmoshub-4",
+  signerAddress: "cosmos1...",
+  data: "Sign in to example.com",
+});
+```
+
+Pass `walletType` when you need to target a specific wallet instead of the active wallet from the Graz store.
+
+## Types
+
+### `SignArbitraryArgs`
+
+```ts
+{
+  walletType?: WalletType;
+  chainId: string;
+  signerAddress: string;
+  data: string | Uint8Array;
+}
+```
+
+The hook and action resolve the wallet, then call `wallet.signArbitrary(chainId, signerAddress, data)`.
+
+## Hook Params
+
+```ts
+{
+  onError?: (error: unknown, args: SignArbitraryArgs) => void | Promise<void>;
+  onLoading?: (args: SignArbitraryArgs) => void;
+  onSuccess?: (signature: StdSignature) => void | Promise<void>;
+}
+```
+
+## Return Value
+
+```tsx
+{
+  // Custom mutation functions
+  signArbitrary: (args: SignArbitraryArgs) => void;
+  signArbitraryAsync: (args: SignArbitraryArgs) => Promise<StdSignature>;
+
+  // React Query mutation properties
+  data?: StdSignature;
+  error: unknown;
+  failureCount: number;
+  failureReason: Error | null;
+  isError: boolean;
+  isIdle: boolean;
+  isPending: boolean;
+  isPaused: boolean;
+  isSuccess: boolean;
+  status: "idle" | "pending" | "error" | "success";
+  variables?: SignArbitraryArgs;
+  submittedAt: number;
+  reset: () => void;
+  context: unknown;
+}
+```
+
+`StdSignature` is from `@cosmjs/amino`.

--- a/docs/docs/hooks/useVerifyArbitrary.md
+++ b/docs/docs/hooks/useVerifyArbitrary.md
@@ -1,0 +1,141 @@
+# useVerifyArbitrary
+
+Mutation hook to verify arbitrary message signatures with the active wallet's ADR-36-compatible verification API.
+
+Use this with signatures produced by `useSignArbitrary` or the `signArbitrary` action. Wallets that do not expose `verifyArbitrary` reject with an explicit unsupported-method error.
+
+## Usage
+
+### Basic Example
+
+```tsx
+import { useAccount, useSignArbitrary, useVerifyArbitrary } from "graz";
+
+function SignAndVerify() {
+  const chainId = "cosmoshub-4";
+  const message = "Sign in to example.com with nonce 12345";
+  const { data: accounts } = useAccount({ chainId: [chainId] });
+  const { signArbitraryAsync } = useSignArbitrary();
+  const { verifyArbitraryAsync, isPending } = useVerifyArbitrary();
+
+  const account = accounts?.[chainId];
+
+  async function handleVerify() {
+    if (!account) return;
+
+    const signature = await signArbitraryAsync({
+      chainId,
+      signerAddress: account.bech32Address,
+      data: message,
+    });
+
+    const verified = await verifyArbitraryAsync({
+      chainId,
+      signerAddress: account.bech32Address,
+      data: message,
+      signature,
+    });
+
+    console.log("Verified:", verified);
+  }
+
+  return (
+    <button onClick={handleVerify} disabled={!account || isPending}>
+      {isPending ? "Verifying..." : "Sign and verify"}
+    </button>
+  );
+}
+```
+
+### With Event Handlers
+
+```tsx
+import { useVerifyArbitrary } from "graz";
+
+function VerifyMessage() {
+  const { verifyArbitrary } = useVerifyArbitrary({
+    onSuccess: (verified) => {
+      console.log("Signature valid:", verified);
+    },
+    onError: (error) => {
+      console.error("Verification failed", error);
+    },
+    onLoading: (args) => {
+      console.log("Verifying message for", args.signerAddress);
+    },
+  });
+
+  // ... call verifyArbitrary({ chainId, signerAddress, data, signature })
+}
+```
+
+### Action Usage
+
+You can call the framework-agnostic action directly outside React components:
+
+```ts
+import { verifyArbitrary } from "graz";
+
+const verified = await verifyArbitrary({
+  chainId: "cosmoshub-4",
+  signerAddress: "cosmos1...",
+  data: "Sign in to example.com",
+  signature,
+});
+```
+
+Pass `walletType` when you need to target a specific wallet instead of the active wallet from the Graz store.
+
+## Types
+
+### `VerifyArbitraryArgs`
+
+```ts
+{
+  walletType?: WalletType;
+  chainId: string;
+  signerAddress: string;
+  data: string | Uint8Array;
+  signature: StdSignature;
+}
+```
+
+The hook and action resolve the wallet, then call `wallet.verifyArbitrary(chainId, signerAddress, data, signature)`.
+
+## Hook Params
+
+```ts
+{
+  onError?: (error: unknown, args: VerifyArbitraryArgs) => void | Promise<void>;
+  onLoading?: (args: VerifyArbitraryArgs) => void;
+  onSuccess?: (verified: boolean) => void | Promise<void>;
+}
+```
+
+## Return Value
+
+```tsx
+{
+  // Custom mutation functions
+  verifyArbitrary: (args: VerifyArbitraryArgs) => void;
+  verifyArbitraryAsync: (args: VerifyArbitraryArgs) => Promise<boolean>;
+
+  // React Query mutation properties
+  data?: boolean;
+  error: unknown;
+  failureCount: number;
+  failureReason: Error | null;
+  isError: boolean;
+  isIdle: boolean;
+  isPending: boolean;
+  isPaused: boolean;
+  isSuccess: boolean;
+  status: "idle" | "pending" | "error" | "success";
+  variables?: VerifyArbitraryArgs;
+  submittedAt: number;
+  reset: () => void;
+  context: unknown;
+}
+```
+
+`StdSignature` is from `@cosmjs/amino`.

--- a/docs/docs/types/Wallet.md
+++ b/docs/docs/types/Wallet.md
@@ -15,6 +15,7 @@ type Wallet = Pick<
   | "signAmino"
 > & {
   signArbitrary?: Keplr["signArbitrary"];
+  verifyArbitrary?: Keplr["verifyArbitrary"];
   subscription?: (reconnect: () => void) => () => void;
   init?: () => Promise<unknown>;
   disable?: (chainIds?: string | undefined) => Promise<void>;

--- a/packages/graz/src/actions/__tests__/methods.test.ts
+++ b/packages/graz/src/actions/__tests__/methods.test.ts
@@ -6,8 +6,12 @@ import {
   getQuerySmart,
   instantiateContract,
   sendIbcTokens,
+  signArbitrary,
   sendTokens,
+  verifyArbitrary,
 } from "../methods";
+import { useGrazInternalStore } from "../../store";
+import { WalletType } from "../../types/wallet";
 
 const txResponse = {
   code: 0,
@@ -22,6 +26,71 @@ const txResponse = {
 };
 
 describe("transaction and query methods", () => {
+  it("delegates arbitrary message signing and verification to the selected wallet", async () => {
+    const signature = {
+      pub_key: { type: "tendermint/PubKeySecp256k1", value: "pubkey" },
+      signature: "signature",
+    };
+    const wallet = {
+      signArbitrary: vi.fn().mockResolvedValue(signature),
+      verifyArbitrary: vi.fn().mockResolvedValue(true),
+    };
+    Object.defineProperty(window, "keplr", {
+      configurable: true,
+      value: wallet,
+    });
+
+    await expect(
+      signArbitrary({
+        chainId: "cosmoshub-4",
+        data: "hello",
+        signerAddress: "cosmos1sender",
+        walletType: WalletType.KEPLR,
+      }),
+    ).resolves.toBe(signature);
+
+    await expect(
+      verifyArbitrary({
+        chainId: "cosmoshub-4",
+        data: "hello",
+        signature,
+        signerAddress: "cosmos1sender",
+        walletType: WalletType.KEPLR,
+      }),
+    ).resolves.toBe(true);
+
+    expect(wallet.signArbitrary).toHaveBeenCalledWith("cosmoshub-4", "cosmos1sender", "hello");
+    expect(wallet.verifyArbitrary).toHaveBeenCalledWith("cosmoshub-4", "cosmos1sender", "hello", signature);
+  });
+
+  it("uses the configured wallet type for arbitrary signing and reports unsupported wallets", async () => {
+    useGrazInternalStore.setState({ walletType: WalletType.KEPLR });
+    Object.defineProperty(window, "keplr", {
+      configurable: true,
+      value: {},
+    });
+
+    await expect(
+      signArbitrary({
+        chainId: "cosmoshub-4",
+        data: "hello",
+        signerAddress: "cosmos1sender",
+      }),
+    ).rejects.toThrow("keplr does not support signArbitrary");
+
+    await expect(
+      verifyArbitrary({
+        chainId: "cosmoshub-4",
+        data: "hello",
+        signature: {
+          pub_key: { type: "tendermint/PubKeySecp256k1", value: "pubkey" },
+          signature: "signature",
+        },
+        signerAddress: "cosmos1sender",
+      }),
+    ).rejects.toThrow("keplr does not support verifyArbitrary");
+  });
+
   it("guards sendTokens inputs and delegates to the signing client", async () => {
     await expect(
       sendTokens({

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -1,14 +1,66 @@
 import type { CosmWasmClient, InstantiateOptions, SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+import type { StdSignature } from "@cosmjs/amino";
 import type { Coin } from "@cosmjs/proto-signing";
 import type { DeliverTxResponse, SigningStargateClient, StdFee } from "@cosmjs/stargate";
 
+import { useGrazInternalStore } from "../store";
 import { LogCategory } from "../types/logger";
+import type { WalletType } from "../types/wallet";
 import { getLogger } from "../utils/logger";
+import { getWallet } from "./wallet";
 
 export interface Height {
   revisionNumber: bigint;
   revisionHeight: bigint;
 }
+
+export interface SignArbitraryArgs {
+  walletType?: WalletType;
+  chainId: string;
+  signerAddress: string;
+  data: string | Uint8Array;
+}
+
+export interface VerifyArbitraryArgs extends SignArbitraryArgs {
+  signature: StdSignature;
+}
+
+/**
+ * Sign arbitrary data using the active wallet's ADR-36-compatible signing API.
+ */
+export const signArbitrary = async ({
+  walletType = useGrazInternalStore.getState().walletType,
+  chainId,
+  signerAddress,
+  data,
+}: SignArbitraryArgs): Promise<StdSignature> => {
+  const wallet = getWallet(walletType);
+
+  if (!wallet.signArbitrary) {
+    throw new Error(`${walletType} does not support signArbitrary`);
+  }
+
+  return wallet.signArbitrary(chainId, signerAddress, data);
+};
+
+/**
+ * Verify arbitrary data using the active wallet's ADR-36-compatible verification API.
+ */
+export const verifyArbitrary = async ({
+  walletType = useGrazInternalStore.getState().walletType,
+  chainId,
+  signerAddress,
+  data,
+  signature,
+}: VerifyArbitraryArgs): Promise<boolean> => {
+  const wallet = getWallet(walletType);
+
+  if (!wallet.verifyArbitrary) {
+    throw new Error(`${walletType} does not support verifyArbitrary`);
+  }
+
+  return wallet.verifyArbitrary(chainId, signerAddress, data, signature);
+};
 
 // https://cosmos.github.io/cosmjs/latest/stargate/classes/SigningStargateClient.html#sendTokens
 export interface SendTokensArgs {

--- a/packages/graz/src/hooks/__tests__/methods.test.tsx
+++ b/packages/graz/src/hooks/__tests__/methods.test.tsx
@@ -15,7 +15,10 @@ import {
   useQuerySmart,
   useSendIbcTokens,
   useSendTokens,
+  useSignArbitrary,
+  useVerifyArbitrary,
 } from "../methods";
+import { WalletType } from "../../types/wallet";
 
 const txResponse = {
   code: 0,
@@ -30,6 +33,54 @@ const txResponse = {
 };
 
 describe("method hooks", () => {
+  it("wraps arbitrary message signing and verification mutations", async () => {
+    const { wrapper } = createQueryWrapper();
+    const signature = {
+      pub_key: { type: "tendermint/PubKeySecp256k1", value: "pubkey" },
+      signature: "signature",
+    };
+    const wallet = {
+      signArbitrary: vi.fn().mockResolvedValue(signature),
+      verifyArbitrary: vi.fn().mockResolvedValue(true),
+    };
+    const signSuccess = vi.fn();
+    const verifySuccess = vi.fn();
+    Object.defineProperty(window, "keplr", {
+      configurable: true,
+      value: wallet,
+    });
+
+    const rendered = renderHook(
+      () => ({
+        sign: useSignArbitrary({ onSuccess: signSuccess }),
+        verify: useVerifyArbitrary({ onSuccess: verifySuccess }),
+      }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await rendered.result.sign.signArbitraryAsync({
+        chainId: "cosmoshub-4",
+        data: "hello",
+        signerAddress: "cosmos1sender",
+        walletType: WalletType.KEPLR,
+      });
+      await rendered.result.verify.verifyArbitraryAsync({
+        chainId: "cosmoshub-4",
+        data: "hello",
+        signature,
+        signerAddress: "cosmos1sender",
+        walletType: WalletType.KEPLR,
+      });
+    });
+
+    expect(wallet.signArbitrary).toHaveBeenCalledWith("cosmoshub-4", "cosmos1sender", "hello");
+    expect(wallet.verifyArbitrary).toHaveBeenCalledWith("cosmoshub-4", "cosmos1sender", "hello", signature);
+    expect(signSuccess).toHaveBeenCalledWith(signature);
+    expect(verifySuccess).toHaveBeenCalledWith(true);
+    rendered.unmount();
+  });
+
   it("wraps token transfer mutations and forwards success callbacks", async () => {
     const { wrapper } = createQueryWrapper();
     const sendTokensSuccess = vi.fn();

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -1,4 +1,5 @@
 import type { ExecuteResult, InstantiateResult } from "@cosmjs/cosmwasm-stargate";
+import type { StdSignature } from "@cosmjs/amino";
 import type { DeliverTxResponse } from "@cosmjs/stargate";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -7,7 +8,9 @@ import type {
   ExecuteContractMutationArgs,
   InstantiateContractMutationArgs,
   SendIbcTokensArgs,
+  SignArbitraryArgs,
   SendTokensArgs,
+  VerifyArbitraryArgs,
 } from "../actions/methods";
 import {
   executeContract,
@@ -15,12 +18,64 @@ import {
   getQuerySmart,
   instantiateContract,
   sendIbcTokens,
+  signArbitrary,
   sendTokens,
+  verifyArbitrary,
 } from "../actions/methods";
 import type { MutationEventArgs } from "../types/hooks";
 import { LogCategory } from "../types/logger";
 import { getLogger } from "../utils/logger";
 import { useCosmWasmClient } from "./clients";
+
+/**
+ * graz mutation hook to sign arbitrary data using the active wallet.
+ *
+ * @see {@link signArbitrary}
+ */
+export const useSignArbitrary = ({
+  onError,
+  onLoading,
+  onSuccess,
+}: MutationEventArgs<SignArbitraryArgs, StdSignature> = {}) => {
+  const { mutate, mutateAsync, ...mutation } = useMutation({
+    mutationKey: ["USE_SIGN_ARBITRARY", onError, onLoading, onSuccess],
+    mutationFn: signArbitrary,
+    onError: (err, data) => Promise.resolve(onError?.(err, data)),
+    onMutate: onLoading,
+    onSuccess: (signature) => Promise.resolve(onSuccess?.(signature)),
+  });
+
+  return {
+    ...mutation,
+    signArbitrary: mutate,
+    signArbitraryAsync: mutateAsync,
+  };
+};
+
+/**
+ * graz mutation hook to verify arbitrary data using the active wallet.
+ *
+ * @see {@link verifyArbitrary}
+ */
+export const useVerifyArbitrary = ({
+  onError,
+  onLoading,
+  onSuccess,
+}: MutationEventArgs<VerifyArbitraryArgs, boolean> = {}) => {
+  const { mutate, mutateAsync, ...mutation } = useMutation({
+    mutationKey: ["USE_VERIFY_ARBITRARY", onError, onLoading, onSuccess],
+    mutationFn: verifyArbitrary,
+    onError: (err, data) => Promise.resolve(onError?.(err, data)),
+    onMutate: onLoading,
+    onSuccess: (verified) => Promise.resolve(onSuccess?.(verified)),
+  });
+
+  return {
+    ...mutation,
+    verifyArbitrary: mutate,
+    verifyArbitraryAsync: mutateAsync,
+  };
+};
 
 /**
  * graz mutation hook to send tokens.

--- a/packages/graz/src/types/wallet.ts
+++ b/packages/graz/src/types/wallet.ts
@@ -61,6 +61,7 @@ export const WALLET_TYPES = [
 export type Wallet = Pick<Keplr, "enable" | "signAmino"> & {
   experimentalSuggestChain: (chainInfo: Omit<ChainInfo, "nodeProvider">) => Promise<void>;
   signArbitrary?: Keplr["signArbitrary"];
+  verifyArbitrary?: Keplr["verifyArbitrary"];
   signDirect: (...args: SignDirectParams) => Promise<DirectSignResponse>;
   getOfflineSigner: (chainId: string, signOptions?: KeplrSignOptions) => OfflineAminoSigner & OfflineDirectSigner;
   getOfflineSignerOnlyAmino: (chainId: string, signOptions?: KeplrSignOptions) => OfflineAminoSigner;


### PR DESCRIPTION
## Summary

Adds public `signArbitrary` and `verifyArbitrary` actions plus matching `useSignArbitrary` and `useVerifyArbitrary` mutation hooks. The implementation delegates to wallet-provided ADR-36-compatible APIs, so wallets without support fail with explicit unsupported-method errors.

Closes #142.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm graz test -- methods`
- `pnpm graz type-check`
- `pnpm graz build`
- `pnpm graz lint`
- `pnpm changeset status --since origin/dev`