### PR TITLE
[codex] fall back to WalletConnect account requests

### DIFF
--- a/.changeset/walletconnect-account-fallback.md
+++ b/.changeset/walletconnect-account-fallback.md
@@ -1,0 +1,5 @@
+---
+"graz": patch
+---
+
+Fall back to WalletConnect account requests when sessions omit stored key properties.

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
@@ -50,6 +50,8 @@ const makeWalletConnectKey = (chainId: string): WalletConnectStoredKey => ({
   pubKey: Buffer.from(new Uint8Array([4, 5, 6])).toString("base64"),
 });
 
+const getWalletConnectChainId = (chainId: string) => chainId.split(":")[1] || chainId;
+
 describe("WalletConnect first-session flow", () => {
   beforeEach(() => {
     walletConnectModalMock.instances.length = 0;
@@ -105,6 +107,44 @@ describe("WalletConnect first-session flow", () => {
       },
       [osmosis.chainId]: {
         bech32Address: osmosis.bech32Address,
+      },
+    });
+  });
+
+  it("requests accounts when an approved session does not include session properties", async () => {
+    const chainId = "cosmoshub-4";
+    const approval = vi.fn().mockResolvedValue({
+      topic: "topic-1",
+    });
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({
+        approval,
+        uri: "wc:topic",
+      }),
+      request: vi.fn(({ chainId: requestChainId }) => [makeWalletConnectKey(getWalletConnectChainId(requestChainId))]),
+      session: {
+        getAll: vi.fn(() => []),
+      },
+    };
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const wallet = getWalletConnect();
+
+    await expect(wallet.enable([chainId])).resolves.toBeUndefined();
+
+    expect(signClient.request).toHaveBeenCalledWith({
+      chainId: `cosmos:${chainId}`,
+      request: {
+        method: "cosmos_getAccounts",
+        params: {},
+      },
+      topic: "topic-1",
+    });
+    expect(useGrazSessionStore.getState().accounts).toMatchObject({
+      [chainId]: {
+        bech32Address: `${chainId}1address`,
       },
     });
   });

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -76,8 +76,10 @@ const makeSignClient = (
     },
     request: vi.fn(async ({ chainId: requestChainId, request }: { chainId?: string; request: { method: string } }) => {
       if (request.method === "cosmos_getAccounts") {
-        const requestedChainId = requestChainId?.split(":")[1] || chainId;
-        return [makeWalletConnectKey(requestedChainId)];
+        if (requestChainId !== `cosmos:${chainId}`) {
+          throw new Error(`Expected cosmos_getAccounts for cosmos:${chainId}, received ${requestChainId}`);
+        }
+        return [makeWalletConnectKey(chainId)];
       }
       if (request.method === "cosmos_signDirect") {
         return {

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -20,8 +20,12 @@ const makeWalletConnectKey = (chainId: string, overrides: Partial<Key> = {}) => 
   ...overrides,
 });
 
-const makeSignClient = (chainId: string, options: { includeSessionProperties?: boolean } = {}) => {
+const makeSignClient = (
+  chainId: string,
+  options: { includeSessionProperties?: boolean; sessionPropertiesChainId?: string } = {},
+) => {
   const includeSessionProperties = options.includeSessionProperties ?? true;
+  const sessionPropertiesChainId = options.sessionPropertiesChainId ?? chainId;
   const listeners = new Map<string, Set<(args?: unknown) => void>>();
   const session = {
     expiry: Math.floor(Date.now() / 1000) + 60,
@@ -33,7 +37,7 @@ const makeSignClient = (chainId: string, options: { includeSessionProperties?: b
     ...(includeSessionProperties
       ? {
           sessionProperties: {
-            keys: JSON.stringify([makeWalletConnectKey(chainId)]),
+            keys: JSON.stringify([makeWalletConnectKey(sessionPropertiesChainId)]),
           },
         }
       : {}),
@@ -70,9 +74,10 @@ const makeSignClient = (chainId: string, options: { includeSessionProperties?: b
         listeners.set(event, eventListeners);
       }),
     },
-    request: vi.fn(async ({ request }: { request: { method: string } }) => {
+    request: vi.fn(async ({ chainId: requestChainId, request }: { chainId?: string; request: { method: string } }) => {
       if (request.method === "cosmos_getAccounts") {
-        return [makeWalletConnectKey(chainId)];
+        const requestedChainId = requestChainId?.split(":")[1] || chainId;
+        return [makeWalletConnectKey(requestedChainId)];
       }
       if (request.method === "cosmos_signDirect") {
         return {
@@ -240,6 +245,37 @@ describe("WalletConnect adapter", () => {
   it("requests accounts for existing sessions without session properties", async () => {
     const chainId = "cosmoshub-4";
     const signClient = makeSignClient(chainId, { includeSessionProperties: false });
+    const wcSignClients = new Map();
+    wcSignClients.set(WalletType.WALLETCONNECT, signClient);
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      wcSignClients,
+    });
+
+    const wallet = getWalletConnect();
+
+    await expect(wallet.getKey(chainId)).resolves.toMatchObject({
+      bech32Address: `${chainId}1address`,
+    });
+    expect(signClient.request).toHaveBeenCalledWith({
+      chainId: `cosmos:${chainId}`,
+      request: {
+        method: "cosmos_getAccounts",
+        params: {},
+      },
+      topic: "topic-1",
+    });
+  });
+
+  it("requests accounts when stored session properties do not include the requested chain", async () => {
+    const chainId = "cosmoshub-4";
+    const signClient = makeSignClient(chainId, { sessionPropertiesChainId: "osmosis-1" });
     const wcSignClients = new Map();
     wcSignClients.set(WalletType.WALLETCONNECT, signClient);
     useGrazInternalStore.setState({

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -20,7 +20,8 @@ const makeWalletConnectKey = (chainId: string, overrides: Partial<Key> = {}) => 
   ...overrides,
 });
 
-const makeSignClient = (chainId: string) => {
+const makeSignClient = (chainId: string, options: { includeSessionProperties?: boolean } = {}) => {
+  const includeSessionProperties = options.includeSessionProperties ?? true;
   const listeners = new Map<string, Set<(args?: unknown) => void>>();
   const session = {
     expiry: Math.floor(Date.now() / 1000) + 60,
@@ -29,9 +30,13 @@ const makeSignClient = (chainId: string) => {
         chains: [`cosmos:${chainId}`],
       },
     },
-    sessionProperties: {
-      keys: JSON.stringify([makeWalletConnectKey(chainId)]),
-    },
+    ...(includeSessionProperties
+      ? {
+          sessionProperties: {
+            keys: JSON.stringify([makeWalletConnectKey(chainId)]),
+          },
+        }
+      : {}),
     topic: "topic-1",
   };
   let sessions = [session];
@@ -66,6 +71,9 @@ const makeSignClient = (chainId: string) => {
       }),
     },
     request: vi.fn(async ({ request }: { request: { method: string } }) => {
+      if (request.method === "cosmos_getAccounts") {
+        return [makeWalletConnectKey(chainId)];
+      }
       if (request.method === "cosmos_signDirect") {
         return {
           signature: {
@@ -226,6 +234,37 @@ describe("WalletConnect adapter", () => {
       _reconnect: false,
       _reconnectConnector: null,
       recentChainIds: null,
+    });
+  });
+
+  it("requests accounts for existing sessions without session properties", async () => {
+    const chainId = "cosmoshub-4";
+    const signClient = makeSignClient(chainId, { includeSessionProperties: false });
+    const wcSignClients = new Map();
+    wcSignClients.set(WalletType.WALLETCONNECT, signClient);
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      wcSignClients,
+    });
+
+    const wallet = getWalletConnect();
+
+    await expect(wallet.getKey(chainId)).resolves.toMatchObject({
+      bech32Address: `${chainId}1address`,
+    });
+    expect(signClient.request).toHaveBeenCalledWith({
+      chainId: `cosmos:${chainId}`,
+      request: {
+        method: "cosmos_getAccounts",
+        params: {},
+      },
+      topic: "topic-1",
     });
   });
 });

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -13,7 +13,7 @@ import { isAndroid, isIos, isMobile } from "../../../utils/os";
 import { promiseWithTimeout } from "../../../utils/timeout";
 import type { GetWalletConnectParams, WalletConnectSignDirectResponse } from "./types";
 
-type WalletConnectStoredKey = Key & { chainId?: string; pubKey: Key["pubKey"] | string };
+type WalletConnectStoredKey = Omit<Key, "pubKey"> & { chainId?: string; pubKey: Key["pubKey"] | string };
 
 export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   if (!useGrazInternalStore.getState().walletConnect?.options?.projectId?.trim()) {
@@ -134,6 +134,8 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     return keys;
   };
 
+  const getWalletConnectChainId = (chainId?: string) => chainId?.split(":")[1] || chainId;
+
   const requestAccounts = async (
     signClient: ISignClient,
     topic: string,
@@ -156,7 +158,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
 
         return accounts.map((account) => ({
           ...account,
-          chainId: account.chainId || chainId,
+          chainId: getWalletConnectChainId(account.chainId) || chainId,
         })) as WalletConnectStoredKey[];
       }),
     );
@@ -169,8 +171,11 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     session: { sessionProperties?: Record<string, string>; topic?: string },
     chainIds: string[],
   ): Promise<WalletConnectStoredKey[]> => {
-    const keys = parseSessionKeys(session.sessionProperties);
-    if (keys) return keys;
+    const keys = parseSessionKeys(session.sessionProperties)?.map((key) => ({
+      ...key,
+      chainId: getWalletConnectChainId(key.chainId),
+    }));
+    if (keys?.some((key) => key.chainId && chainIds.includes(key.chainId))) return keys;
     if (!session.topic) throw new Error("No wallet connect session");
 
     return requestAccounts(signClient, session.topic, chainIds);
@@ -291,7 +296,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
                   isNanoLedger: x.isNanoLedger,
                   isKeystone: x.isKeystone,
                   name: x.name,
-                  pubKey: x.pubKey,
+                  pubKey: Buffer.from(String(x.pubKey), encoding),
                 };
               });
               useGrazSessionStore.setState((prev) => ({

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -13,6 +13,8 @@ import { isAndroid, isIos, isMobile } from "../../../utils/os";
 import { promiseWithTimeout } from "../../../utils/timeout";
 import type { GetWalletConnectParams, WalletConnectSignDirectResponse } from "./types";
 
+type WalletConnectStoredKey = Key & { chainId?: string; pubKey: Key["pubKey"] | string };
+
 export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   if (!useGrazInternalStore.getState().walletConnect?.options?.projectId?.trim()) {
     throw new Error("walletConnect.options.projectId is not defined");
@@ -122,6 +124,58 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     }
   };
 
+  const parseSessionKeys = (sessionProperties?: Record<string, string>): WalletConnectStoredKey[] | undefined => {
+    const rawKeys = sessionProperties?.keys;
+    if (!rawKeys) return;
+
+    const keys = JSON.parse(String(rawKeys)) as WalletConnectStoredKey[];
+    if (!Array.isArray(keys) || keys.length === 0) throw new Error("No accounts");
+
+    return keys;
+  };
+
+  const requestAccounts = async (
+    signClient: ISignClient,
+    topic: string,
+    chainIds: string[],
+  ): Promise<WalletConnectStoredKey[]> => {
+    const keysByChainId = await Promise.all(
+      chainIds.map(async (chainId) => {
+        const response = await signClient.request({
+          topic,
+          chainId: `cosmos:${chainId}`,
+          request: {
+            method: "cosmos_getAccounts",
+            params: {},
+          },
+        });
+        const accounts = Array.isArray(response)
+          ? response
+          : (response as { accounts?: WalletConnectStoredKey[] }).accounts;
+        if (!Array.isArray(accounts) || accounts.length === 0) throw new Error("No accounts");
+
+        return accounts.map((account) => ({
+          ...account,
+          chainId: account.chainId || chainId,
+        })) as WalletConnectStoredKey[];
+      }),
+    );
+
+    return keysByChainId.flat();
+  };
+
+  const getSessionKeys = async (
+    signClient: ISignClient,
+    session: { sessionProperties?: Record<string, string>; topic?: string },
+    chainIds: string[],
+  ): Promise<WalletConnectStoredKey[]> => {
+    const keys = parseSessionKeys(session.sessionProperties);
+    if (keys) return keys;
+    if (!session.topic) throw new Error("No wallet connect session");
+
+    return requestAccounts(signClient, session.topic, chainIds);
+  };
+
   const init = async () => {
     const { walletConnect } = useGrazInternalStore.getState();
     if (!walletConnect?.options) throw new Error("walletConnect.options is not defined");
@@ -222,16 +276,15 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
         if (signal.aborted) return Promise.reject(new Error("User closed wallet connect"));
         return new Promise((resolve, reject) => {
           approval()
-            .then((d) => {
-              const sessionProperties = d.sessionProperties;
-              if (!sessionProperties) return reject(new Error("No session properties"));
-              const _acc: (Key & { chainId?: string })[] = JSON.parse(String(sessionProperties.keys));
+            .then(async (d) => {
+              const _acc = await getSessionKeys(signClient, d, chainId);
               if (_acc.length === 0) return reject(new Error("No accounts"));
               const acc = _acc[0];
               if (!acc) return reject(new Error("No accounts"));
               const resAcc: Record<string, Key> = {};
               _acc.forEach((x) => {
-                resAcc[x.chainId!] = {
+                if (!x.chainId) return;
+                resAcc[x.chainId] = {
                   address: x.address,
                   algo: x.algo as Algo,
                   bech32Address: x.bech32Address,
@@ -309,10 +362,11 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   const getKey = async (chainId: string): Promise<Key> => {
     const session = getSession([chainId]);
     if (!session?.topic) throw new Error("No wallet connect session");
+    const { wcSignClients } = useGrazSessionStore.getState();
+    const wcSignClient = wcSignClients.get(walletType);
+    if (!wcSignClient) throw new Error("walletConnect.signClient is not defined");
 
-    const keys: (Key & { chainId: string })[] | undefined =
-      session.sessionProperties && JSON.parse(String(session.sessionProperties.keys));
-    if (!keys) throw new Error("No wallet connect key");
+    const keys = await getSessionKeys(wcSignClient, session, [chainId]);
     if (keys.length === 0) throw new Error("No wallet connect session");
     const key = keys.find((x) => x.chainId === chainId);
     if (!key) throw new Error(`No wallet connect key for chainId ${chainId}`);


### PR DESCRIPTION
## Summary

Fixes WalletConnect sessions that approve successfully but do not include `sessionProperties.keys`. The adapter now keeps the existing session-property path for wallets that provide it, and falls back to `cosmos_getAccounts` for each requested chain when those stored keys are missing.

This covers both first-session approval and later `getKey` calls against existing sessions.

Closes #139.

## Validation

- `pnpm graz test -- wallet-connect`
- `pnpm graz type-check`
- `pnpm graz build`
- `pnpm graz lint`
- `pnpm changeset status --since origin/dev`