### PR TITLE
[codex] add sign and broadcast hook

### DIFF
--- a/.changeset/sign-and-broadcast-hook.md
+++ b/.changeset/sign-and-broadcast-hook.md
@@ -1,0 +1,5 @@
+---
+"graz": patch
+---
+
+Add signAndBroadcast action and mutation hook for encoded messages.

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -316,6 +316,7 @@ Now that you have a working setup, explore more features:
 - 🪝 [useAccount](./hooks/useAccount) - Account information
 - 💰 [useBalance](./hooks/useBalance) - Query balances
 - 📤 [useSendTokens](./hooks/useSendTokens) - Send transactions
+- 🧾 [useSignAndBroadcast](./hooks/useSignAndBroadcast) - Broadcast custom Cosmos messages
 - 📜 [useExecuteContract](./hooks/useExecuteContract) - Smart contract interactions
 
 ### Advanced Topics

--- a/docs/docs/hooks/useSignAndBroadcast.md
+++ b/docs/docs/hooks/useSignAndBroadcast.md
@@ -1,0 +1,74 @@
+# useSignAndBroadcast
+
+Mutation hook to sign and broadcast arbitrary encoded Cosmos messages with a `SigningStargateClient`.
+
+## Usage
+
+```tsx
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import { useAccount, useSignAndBroadcast, useStargateSigningClient } from "graz";
+
+function BroadcastMessages() {
+  const { data: accounts } = useAccount({ chainId: ["cosmoshub-4"] });
+  const { data: signingClients } = useStargateSigningClient({ chainId: ["cosmoshub-4"] });
+  const { signAndBroadcastAsync, isPending } = useSignAndBroadcast();
+
+  const account = accounts?.["cosmoshub-4"];
+  const signingClient = signingClients?.["cosmoshub-4"];
+
+  async function broadcast() {
+    if (!account || !signingClient) return;
+
+    const messages: EncodeObject[] = [
+      {
+        typeUrl: "/cosmos.bank.v1beta1.MsgSend",
+        value: {
+          fromAddress: account.bech32Address,
+          toAddress: "cosmos1recipient...",
+          amount: [{ denom: "uatom", amount: "1000" }],
+        },
+      },
+    ];
+
+    const result = await signAndBroadcastAsync({
+      signingClient,
+      senderAddress: account.bech32Address,
+      messages,
+      fee: "auto",
+      memo: "Sent via Graz",
+    });
+
+    console.log(result.transactionHash);
+  }
+
+  return (
+    <button onClick={broadcast} disabled={isPending}>
+      Broadcast
+    </button>
+  );
+}
+```
+
+## Types
+
+### `SignAndBroadcastArgs`
+
+```ts
+{
+  signingClient: SigningStargateClient;
+  senderAddress: string;
+  messages: readonly EncodeObject[];
+  fee: number | StdFee | "auto";
+  memo?: string;
+  timeoutHeight?: bigint;
+}
+```
+
+## Return Value
+
+```ts
+{
+  signAndBroadcast: (args: SignAndBroadcastArgs) => void;
+  signAndBroadcastAsync: (args: SignAndBroadcastArgs) => Promise<DeliverTxResponse>;
+}
+```

--- a/docs/docs/hooks/useSignAndBroadcast.md
+++ b/docs/docs/hooks/useSignAndBroadcast.md
@@ -2,7 +2,17 @@
 
 Mutation hook to sign and broadcast arbitrary encoded Cosmos messages with a `SigningStargateClient`.
 
+Use this when you already have one or more `EncodeObject` messages and want Graz to call CosmJS'
+`signAndBroadcast` directly.
+
+**Important**: `senderAddress` is a required parameter that must be explicitly provided.
+
+**Enhanced**: This hook returns all React Query mutation properties, giving you access to utilities like
+`reset`, `variables`, `context`, `failureCount`, and more.
+
 ## Usage
+
+### Basic Example
 
 ```tsx
 import type { EncodeObject } from "@cosmjs/proto-signing";
@@ -49,28 +59,117 @@ function BroadcastMessages() {
 }
 ```
 
+### With Event Handlers
+
+```tsx
+import { useSignAndBroadcast } from "graz";
+
+function BroadcastWithEvents() {
+  const { signAndBroadcastAsync } = useSignAndBroadcast({
+    onSuccess: (data) => {
+      console.log("Transaction successful!", data.transactionHash);
+    },
+    onError: (error) => {
+      console.error("Transaction failed:", error);
+    },
+    onLoading: (args) => {
+      console.log("Broadcasting messages...", args.messages.length);
+    },
+  });
+
+  // ... rest of component
+}
+```
+
+### Framework-Agnostic Action
+
+`signAndBroadcast` is also available as a public action for non-React usage.
+
+```ts
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import { signAndBroadcast } from "graz";
+
+const messages: EncodeObject[] = [
+  {
+    typeUrl: "/cosmos.bank.v1beta1.MsgSend",
+    value: {
+      fromAddress: senderAddress,
+      toAddress: "cosmos1recipient...",
+      amount: [{ denom: "uatom", amount: "1000" }],
+    },
+  },
+];
+
+const result = await signAndBroadcast({
+  signingClient,
+  senderAddress,
+  messages,
+  fee: "auto",
+  memo: "Sent via Graz",
+});
+
+console.log(result.transactionHash);
+```
+
 ## Types
 
 ### `SignAndBroadcastArgs`
 
 ```ts
 {
-  signingClient?: SigningStargateClient;
-  senderAddress?: string;
-  messages: readonly EncodeObject[];
+  signingClient?: SigningStargateClient; // Required at runtime
+  senderAddress?: string; // Required at runtime - address signing the messages
+  messages: readonly EncodeObject[]; // Cosmos messages to sign and broadcast
   fee: number | StdFee | "auto";
   memo?: string;
   timeoutHeight?: bigint;
 }
 ```
 
-`signingClient` and `senderAddress` are optional so the hook can be initialized before wallet connection data is ready. The action still requires them at runtime and throws if either value is missing.
+`signingClient` and `senderAddress` are optional at the TypeScript action boundary so mutation args can be
+assembled from wallet state that may still be loading. The action still requires them at runtime and throws if
+either value is missing.
 
-## Return Value
+## Hook Params
+
+Object params for event handlers:
 
 ```ts
 {
-  signAndBroadcast: (args: SignAndBroadcastArgs) => void;
-  signAndBroadcastAsync: (args: SignAndBroadcastArgs) => Promise<DeliverTxResponse>;
+  onError?: (error: unknown, args: SignAndBroadcastArgs) => void | Promise<void>;
+  onLoading?: (args: SignAndBroadcastArgs) => void;
+  onSuccess?: (data: DeliverTxResponse) => void | Promise<void>;
 }
 ```
+
+## Return Value
+
+```tsx
+{
+  // Custom mutation functions
+  signAndBroadcast: (args: SignAndBroadcastArgs) => void;
+  signAndBroadcastAsync: (args: SignAndBroadcastArgs) => Promise<DeliverTxResponse>;
+
+  // All React Query mutation properties
+  data?: DeliverTxResponse; // From @cosmjs/stargate
+  error: unknown;
+  failureCount: number;
+  failureReason: Error | null;
+  isError: boolean;
+  isIdle: boolean;
+  isPending: boolean;
+  isPaused: boolean;
+  isSuccess: boolean;
+  status: "idle" | "pending" | "error" | "success";
+  variables?: SignAndBroadcastArgs; // Arguments passed to the last mutation call
+  submittedAt: number;
+
+  // Mutation methods
+  reset: () => void; // Reset mutation state
+
+  // Context (from onLoading)
+  context: unknown;
+}
+```
+
+Note: `isLoading` has been replaced by `isPending` in React Query v5. Both work, but `isPending` is the modern property name.

--- a/docs/docs/hooks/useSignAndBroadcast.md
+++ b/docs/docs/hooks/useSignAndBroadcast.md
@@ -55,8 +55,8 @@ function BroadcastMessages() {
 
 ```ts
 {
-  signingClient: SigningStargateClient;
-  senderAddress: string;
+  signingClient?: SigningStargateClient;
+  senderAddress?: string;
   messages: readonly EncodeObject[];
   fee: number | StdFee | "auto";
   memo?: string;

--- a/docs/docs/hooks/useSignAndBroadcast.md
+++ b/docs/docs/hooks/useSignAndBroadcast.md
@@ -64,6 +64,8 @@ function BroadcastMessages() {
 }
 ```
 
+`signingClient` and `senderAddress` are optional so the hook can be initialized before wallet connection data is ready. The action still requires them at runtime and throws if either value is missing.
+
 ## Return Value
 
 ```ts

--- a/packages/graz/src/actions/__tests__/methods.test.ts
+++ b/packages/graz/src/actions/__tests__/methods.test.ts
@@ -7,6 +7,7 @@ import {
   instantiateContract,
   sendIbcTokens,
   sendTokens,
+  signAndBroadcast,
 } from "../methods";
 
 const txResponse = {
@@ -22,6 +23,59 @@ const txResponse = {
 };
 
 describe("transaction and query methods", () => {
+  it("guards signAndBroadcast inputs and delegates to the signing client", async () => {
+    await expect(
+      signAndBroadcast({
+        fee: "auto",
+        messages: [],
+      }),
+    ).rejects.toThrow("Stargate signing client is not ready");
+
+    const signingClient = {
+      signAndBroadcast: vi.fn().mockResolvedValue(txResponse),
+    };
+    const messages = [{ typeUrl: "/cosmos.bank.v1beta1.MsgSend", value: {} }];
+
+    await expect(
+      signAndBroadcast({
+        fee: "auto",
+        memo: "memo",
+        messages,
+        senderAddress: "cosmos1sender",
+        signingClient: signingClient as never,
+        timeoutHeight: 123n,
+      }),
+    ).resolves.toBe(txResponse);
+
+    expect(signingClient.signAndBroadcast).toHaveBeenCalledWith(
+      "cosmos1sender",
+      messages,
+      "auto",
+      "memo",
+      123n,
+    );
+
+    await expect(
+      signAndBroadcast({
+        fee: "auto",
+        messages,
+        senderAddress: "",
+        signingClient: signingClient as never,
+      }),
+    ).rejects.toThrow("senderAddress is not defined");
+
+    const error = new Error("broadcast failed");
+    signingClient.signAndBroadcast.mockRejectedValueOnce(error);
+    await expect(
+      signAndBroadcast({
+        fee: "auto",
+        messages,
+        senderAddress: "cosmos1sender",
+        signingClient: signingClient as never,
+      }),
+    ).rejects.toBe(error);
+  });
+
   it("guards sendTokens inputs and delegates to the signing client", async () => {
     await expect(
       sendTokens({

--- a/packages/graz/src/actions/methods.ts
+++ b/packages/graz/src/actions/methods.ts
@@ -1,5 +1,5 @@
 import type { CosmWasmClient, InstantiateOptions, SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
-import type { Coin } from "@cosmjs/proto-signing";
+import type { Coin, EncodeObject } from "@cosmjs/proto-signing";
 import type { DeliverTxResponse, SigningStargateClient, StdFee } from "@cosmjs/stargate";
 
 import { LogCategory } from "../types/logger";
@@ -9,6 +9,59 @@ export interface Height {
   revisionNumber: bigint;
   revisionHeight: bigint;
 }
+
+// https://cosmos.github.io/cosmjs/latest/stargate/classes/SigningStargateClient.html#signAndBroadcast
+export interface SignAndBroadcastArgs {
+  signingClient?: SigningStargateClient;
+  senderAddress?: string;
+  messages: readonly EncodeObject[];
+  fee: number | StdFee | "auto";
+  memo?: string;
+  timeoutHeight?: bigint;
+}
+
+export const signAndBroadcast = async ({
+  signingClient,
+  senderAddress,
+  messages,
+  fee,
+  memo,
+  timeoutHeight,
+}: SignAndBroadcastArgs): Promise<DeliverTxResponse> => {
+  const logger = getLogger();
+
+  if (!signingClient) {
+    throw new Error("Stargate signing client is not ready");
+  }
+  if (!senderAddress) {
+    throw new Error("senderAddress is not defined");
+  }
+
+  logger.debug(LogCategory.TRANSACTION, "Signing and broadcasting transaction", {
+    function: "signAndBroadcast",
+    senderAddress,
+    messageCount: messages.length,
+  });
+
+  try {
+    const result = await signingClient.signAndBroadcast(senderAddress, messages, fee, memo, timeoutHeight);
+
+    logger.info(LogCategory.TRANSACTION, "Transaction broadcasted", {
+      function: "signAndBroadcast",
+      txHash: result.transactionHash,
+      height: result.height,
+    });
+
+    return result;
+  } catch (error) {
+    logger.error(LogCategory.TRANSACTION, "Transaction failed", {
+      function: "signAndBroadcast",
+      error: error instanceof Error ? error.message : String(error),
+      senderAddress,
+    });
+    throw error;
+  }
+};
 
 // https://cosmos.github.io/cosmjs/latest/stargate/classes/SigningStargateClient.html#sendTokens
 export interface SendTokensArgs {

--- a/packages/graz/src/hooks/__tests__/methods.test.tsx
+++ b/packages/graz/src/hooks/__tests__/methods.test.tsx
@@ -15,6 +15,7 @@ import {
   useQuerySmart,
   useSendIbcTokens,
   useSendTokens,
+  useSignAndBroadcast,
 } from "../methods";
 
 const txResponse = {
@@ -30,6 +31,37 @@ const txResponse = {
 };
 
 describe("method hooks", () => {
+  it("wraps signAndBroadcast mutations and forwards success callbacks", async () => {
+    const { wrapper } = createQueryWrapper();
+    const signAndBroadcastSuccess = vi.fn();
+    const signingClient = {
+      signAndBroadcast: vi.fn().mockResolvedValue(txResponse),
+    };
+    const messages = [{ typeUrl: "/cosmos.bank.v1beta1.MsgSend", value: {} }];
+
+    const rendered = renderHook(() => useSignAndBroadcast({ onSuccess: signAndBroadcastSuccess }), { wrapper });
+
+    await act(async () => {
+      await rendered.result.signAndBroadcastAsync({
+        fee: "auto",
+        memo: "memo",
+        messages,
+        senderAddress: "cosmos1sender",
+        signingClient: signingClient as never,
+      });
+    });
+
+    expect(signingClient.signAndBroadcast).toHaveBeenCalledWith(
+      "cosmos1sender",
+      messages,
+      "auto",
+      "memo",
+      undefined,
+    );
+    expect(signAndBroadcastSuccess).toHaveBeenCalledWith(txResponse);
+    rendered.unmount();
+  });
+
   it("wraps token transfer mutations and forwards success callbacks", async () => {
     const { wrapper } = createQueryWrapper();
     const sendTokensSuccess = vi.fn();

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -8,6 +8,7 @@ import type {
   InstantiateContractMutationArgs,
   SendIbcTokensArgs,
   SendTokensArgs,
+  SignAndBroadcastArgs,
 } from "../actions/methods";
 import {
   executeContract,
@@ -16,11 +17,51 @@ import {
   instantiateContract,
   sendIbcTokens,
   sendTokens,
+  signAndBroadcast,
 } from "../actions/methods";
 import type { MutationEventArgs } from "../types/hooks";
 import { LogCategory } from "../types/logger";
 import { getLogger } from "../utils/logger";
 import { useCosmWasmClient } from "./clients";
+
+/**
+ * graz mutation hook to sign and broadcast arbitrary encoded messages.
+ *
+ * @see {@link signAndBroadcast}
+ */
+export const useSignAndBroadcast = ({
+  onError,
+  onLoading,
+  onSuccess,
+}: MutationEventArgs<SignAndBroadcastArgs, DeliverTxResponse> = {}) => {
+  const logger = getLogger();
+  const { mutate, mutateAsync, ...mutation } = useMutation({
+    mutationKey: ["USE_SIGN_AND_BROADCAST", onError, onLoading, onSuccess],
+    mutationFn: signAndBroadcast,
+    onError: (err, data) => {
+      logger.error(LogCategory.TRANSACTION, "useSignAndBroadcast mutation failed", {
+        hook: "useSignAndBroadcast",
+        error: err instanceof Error ? err.message : String(err),
+        messageCount: data.messages.length,
+      });
+      return Promise.resolve(onError?.(err, data));
+    },
+    onMutate: onLoading,
+    onSuccess: (txResponse) => {
+      logger.info(LogCategory.TRANSACTION, "useSignAndBroadcast mutation successful", {
+        hook: "useSignAndBroadcast",
+        txHash: txResponse.transactionHash,
+      });
+      return Promise.resolve(onSuccess?.(txResponse));
+    },
+  });
+
+  return {
+    ...mutation,
+    signAndBroadcast: mutate,
+    signAndBroadcastAsync: mutateAsync,
+  };
+};
 
 /**
  * graz mutation hook to send tokens.

--- a/packages/graz/src/hooks/methods.ts
+++ b/packages/graz/src/hooks/methods.ts
@@ -36,13 +36,13 @@ export const useSignAndBroadcast = ({
 }: MutationEventArgs<SignAndBroadcastArgs, DeliverTxResponse> = {}) => {
   const logger = getLogger();
   const { mutate, mutateAsync, ...mutation } = useMutation({
-    mutationKey: ["USE_SIGN_AND_BROADCAST", onError, onLoading, onSuccess],
+    mutationKey: ["USE_SIGN_AND_BROADCAST"],
     mutationFn: signAndBroadcast,
     onError: (err, data) => {
       logger.error(LogCategory.TRANSACTION, "useSignAndBroadcast mutation failed", {
         hook: "useSignAndBroadcast",
         error: err instanceof Error ? err.message : String(err),
-        messageCount: data.messages.length,
+        messageCount: data?.messages?.length ?? 0,
       });
       return Promise.resolve(onError?.(err, data));
     },


### PR DESCRIPTION
## Summary

Adds a `signAndBroadcast` action and `useSignAndBroadcast` mutation hook for broadcasting arbitrary encoded Cosmos messages through a `SigningStargateClient`. The helper mirrors the existing transaction method style with explicit `signingClient` and `senderAddress` arguments, logging, input guards, tests, docs, and a patch changeset.

Closes #81.

## Validation

- `pnpm graz test -- methods`
- `pnpm graz type-check`
- `pnpm graz build`
- `pnpm graz lint`
- `pnpm project:docs build`
- `pnpm changeset status --since origin/dev`