### PR TITLE
[codex] fix QueryClientProvider docs

### DIFF
--- a/.changeset/query-client-provider-docs.md
+++ b/.changeset/query-client-provider-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix QueryClientProvider examples to use the current `client` prop.

--- a/docs/docs/provider/grazProvider.md
+++ b/docs/docs/provider/grazProvider.md
@@ -34,7 +34,7 @@ export default function CustomApp({ Component, pageProps }: AppProps) {
   };
 
   return (
-    <QueryClientProvider queryClient={queryClient}>
+    <QueryClientProvider client={queryClient}>
       <GrazProvider
         grazOptions={{
           chains: [cosmoshub, sommelier],

--- a/packages/graz/src/provider/index.tsx
+++ b/packages/graz/src/provider/index.tsx
@@ -20,7 +20,7 @@ export interface GrazProviderProps {
  * // example next.js application in _app.tsx
  * export default function CustomApp({ Component, pageProps }: AppProps) {
  *   return (
- *     <QueryClientProvider queryClient={queryClient}>
+ *     <QueryClientProvider client={queryClient}>
  *       <GrazProvider grazOptions={{
  *         chains: [cosmoshubChainInfo, osmosisChainInfo],
  *         logger: {


### PR DESCRIPTION
## Summary

Fixes stale QueryClientProvider examples to use the current TanStack Query `client` prop. Graz already expects consumers to provide their own QueryClientProvider; this keeps the provider docs and source JSDoc aligned with that current integration model.

Closes #141 and closes #36.

## Validation

- `rg "QueryClientProvider queryClient|\<QueryClientProvider\s+queryClient" docs packages/graz/src packages/graz/README.md README.md -g "*.{md,mdx,ts,tsx}"`
- `pnpm project:docs build`
- `pnpm graz type-check`
- `pnpm changeset status --since origin/dev`