### PR TITLE
[codex] Add explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ on:
       - pnpm-workspace.yaml
       - turbo.json
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build & Test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ on:
       - pnpm-workspace.yaml
       - turbo.json
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Summary

- Add top-level read-only `GITHUB_TOKEN` permissions to the lint workflow for CodeQL alert 27.
- Add top-level read-only `GITHUB_TOKEN` permissions to the CI workflow for CodeQL alerts 28 and 29.
- Keep all existing workflow triggers and job behavior unchanged.

## Why

GitHub code scanning reports `actions/missing-workflow-permissions` when workflows rely on default token permissions. These workflows only need repository read access for checkout/install/build/test steps, so `contents: read` is the least-privilege setting.

Related alerts:
- https://github.com/graz-sh/graz/security/code-scanning/27
- https://github.com/graz-sh/graz/security/code-scanning/28
- https://github.com/graz-sh/graz/security/code-scanning/29

## Validation

- Parsed `.github/workflows/ci.yml` and `.github/workflows/lint.yml` with the repo's `yaml` package and verified `permissions.contents === "read"`.
- Confirmed the branch diff only touches the two reported workflow files.
- Attempted `pnpm exec actionlint .github/workflows/ci.yml .github/workflows/lint.yml`; actionlint is not installed in this workspace.

@coderabbitai review