### PR TITLE
[codex] Use GitHub App token for release PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -98,4 +98,4 @@ Use `nvm use` instead of `fnm use 24.17.0` in shells that rely on nvm.
 
 - Keep workflow action SHAs paired with readable version comments.
 - Keep root dependency and toolchain files in path filters so lockfile, pnpm, Node, Turbo, and ESLint changes trigger CI.
-- `PERSONAL_TOKEN` is used by the Changesets action to create release pull requests.
+- `CHANGESETS_APP_CLIENT_ID` and `CHANGESETS_APP_PRIVATE_KEY` are used to mint a GitHub App token for Changesets release pull requests.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,11 +102,20 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Create GitHub App token
+        id: changesets-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.CHANGESETS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGESETS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.changesets-app-token.outputs.token }}
 
   publish:
     name: Publish to npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,6 +87,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -114,6 +116,8 @@ jobs:
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.changesets-app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary
- mint a GitHub App installation token in the Release workflow before `changesets/action`
- pass that app token to the Changesets version PR step instead of `secrets.PERSONAL_TOKEN`
- request only `contents: write` and `pull_requests: write` from the installation token

## Why
The current `PERSONAL_TOKEN` secret failed the org classic-PAT lifetime policy. Using `github.token` avoids the PAT but leaves release PR checks approval-gated. A GitHub App installation token avoids personal credentials while still letting PR workflows run normally.

## GitHub App setup
Created and installed `graz-changesets-release` on `graz-sh/graz` only.

Configured repo settings:
- repository variable `CHANGESETS_APP_CLIENT_ID`
- repository secret `CHANGESETS_APP_PRIVATE_KEY`

App/token verification:
- app slug: `graz-changesets-release`
- app id: `4139200`
- installation id: `142464634`
- repository selection: selected repositories
- token permissions verified: `contents: write`, `pull_requests: write`, `metadata: read`
- token repository count: 1

## Validation
- Parsed `.github/workflows/publish.yml` with Ruby YAML loader
- Confirmed `actions/create-github-app-token@v3.2.0` points to pinned SHA `bcd2ba49218906704ab6c1aa796996da409d3eb1`
- Generated a JWT from the stored app private key and successfully minted an installation token for `graz-sh/graz` with the workflow-requested permissions

## Note
I checked existing app installations; the previous `changeset-bot` app only has `contents: read`, so it could not replace the PAT for creating/updating the version PR branch.