### PR TITLE
docs: add try it out example

### DIFF
--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -4,6 +4,10 @@ sidebar_position: 5
 
 # Examples
 
+## Try it out
+
+Start with the [Try it out](./try-it-out) page for a small React example that configures Graz, connects a Cosmos wallet, and queries an ATOM balance.
+
 ## Playground (Next.js)
 
 A comprehensive example application showcasing Graz's multi-chain wallet integration capabilities.

--- a/docs/docs/examples/try-it-out.mdx
+++ b/docs/docs/examples/try-it-out.mdx
@@ -66,14 +66,26 @@ function WalletExample() {
   });
 
   const account = accounts?.[chainId];
-  const { data: balance, isLoading: isBalanceLoading } = useBalance({
+  const {
+    data: balance,
+    error: balanceError,
+    isError: isBalanceError,
+    isLoading: isBalanceLoading,
+  } = useBalance({
     chainId,
     bech32Address: account?.bech32Address ?? "",
     denom: "uatom",
     enabled: Boolean(account?.bech32Address),
   });
 
-  const atomBalance = balance ? Number(balance.amount) / 1_000_000 : 0;
+  const atomBalance = balance ? Number(balance.amount) / 1_000_000 : undefined;
+  const balanceStatus = isBalanceLoading
+    ? "Loading..."
+    : isBalanceError
+      ? (balanceError?.message ?? "Unable to load balance")
+      : atomBalance === undefined
+        ? "No ATOM balance found"
+        : `${atomBalance.toFixed(6)} ATOM`;
 
   return (
     <main style={{ maxWidth: 640, margin: "4rem auto", fontFamily: "sans-serif" }}>
@@ -86,7 +98,7 @@ function WalletExample() {
             <strong>Address:</strong> {account.bech32Address}
           </p>
           <p>
-            <strong>Balance:</strong> {isBalanceLoading ? "Loading..." : `${atomBalance.toFixed(6)} ATOM`}
+            <strong>Balance:</strong> {balanceStatus}
           </p>
           <button disabled={isDisconnecting} onClick={() => disconnect()}>
             Disconnect
@@ -138,5 +150,5 @@ export default function App() {
 ## Try more flows
 
 - Use [Getting Started](../getting-started) for the step-by-step setup guide.
-- Use [WalletConnect](../wallet-connect) when you need QR or mobile wallet connections.
-- Use the [Playground example](https://graz.sh/examples/playground) for multi-chain connections, balances, contracts, clients, and token sends.
+- Open [WalletConnect](../wallet-connect) when you need QR or mobile wallet connections.
+- Explore the [Playground example](https://graz.sh/examples/playground) for multi-chain connections, balances, contracts, clients, and token sends.

--- a/docs/docs/examples/try-it-out.mdx
+++ b/docs/docs/examples/try-it-out.mdx
@@ -1,0 +1,142 @@
+---
+sidebar_position: 1
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# Try it out
+
+Use this example when you want the smallest useful Graz app: one provider setup, one wallet connection, and one balance query against Cosmos Hub.
+
+## Create a React app
+
+Start from Vite's React TypeScript template, then install Graz and its peer dependencies.
+
+<Tabs>
+<TabItem value="npm" label="npm">
+
+```shell
+npm create vite@latest graz-try-it-out -- --template react-ts
+cd graz-try-it-out
+npm install graz @cosmjs/cosmwasm-stargate @cosmjs/proto-signing @cosmjs/stargate @cosmjs/encoding @tanstack/react-query
+npm run dev
+```
+
+</TabItem>
+<TabItem value="yarn" label="yarn">
+
+```shell
+yarn create vite graz-try-it-out --template react-ts
+cd graz-try-it-out
+yarn add graz @cosmjs/cosmwasm-stargate @cosmjs/proto-signing @cosmjs/stargate @cosmjs/encoding @tanstack/react-query
+yarn dev
+```
+
+</TabItem>
+<TabItem value="pnpm" label="pnpm">
+
+```shell
+pnpm create vite graz-try-it-out --template react-ts
+cd graz-try-it-out
+pnpm add graz @cosmjs/cosmwasm-stargate @cosmjs/proto-signing @cosmjs/stargate @cosmjs/encoding @tanstack/react-query
+pnpm dev
+```
+
+</TabItem>
+</Tabs>
+
+## Add Graz providers
+
+Replace the generated `src/App.tsx` with this example. Install Keplr, Leap, or another supported Cosmos wallet before clicking **Connect wallet**.
+
+```tsx title="src/App.tsx"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { GrazProvider, WalletType, useAccount, useBalance, useConnect, useDisconnect } from "graz";
+import { cosmoshub } from "graz/chains";
+
+const queryClient = new QueryClient();
+const chainId = "cosmoshub-4";
+
+function WalletExample() {
+  const { connect, isLoading: isConnecting, status } = useConnect();
+  const { disconnect, isLoading: isDisconnecting } = useDisconnect();
+  const { data: accounts, isConnected } = useAccount({
+    chainId: [chainId] as const,
+  });
+
+  const account = accounts?.[chainId];
+  const { data: balance, isLoading: isBalanceLoading } = useBalance({
+    chainId,
+    bech32Address: account?.bech32Address ?? "",
+    denom: "uatom",
+    enabled: Boolean(account?.bech32Address),
+  });
+
+  const atomBalance = balance ? Number(balance.amount) / 1_000_000 : 0;
+
+  return (
+    <main style={{ maxWidth: 640, margin: "4rem auto", fontFamily: "sans-serif" }}>
+      <h1>Graz wallet example</h1>
+      <p>Connect a Cosmos wallet and read your ATOM balance.</p>
+
+      {account ? (
+        <section>
+          <p>
+            <strong>Address:</strong> {account.bech32Address}
+          </p>
+          <p>
+            <strong>Balance:</strong> {isBalanceLoading ? "Loading..." : `${atomBalance.toFixed(6)} ATOM`}
+          </p>
+          <button disabled={isDisconnecting} onClick={() => disconnect()}>
+            Disconnect
+          </button>
+        </section>
+      ) : (
+        <section>
+          <p>Status: {status}</p>
+          <button
+            disabled={isConnecting}
+            onClick={() =>
+              connect({
+                chainId: [chainId],
+                walletType: WalletType.KEPLR,
+              })
+            }
+          >
+            Connect wallet
+          </button>
+        </section>
+      )}
+
+      {!isConnected && (
+        <p>
+          Change <code>WalletType.KEPLR</code> to <code>WalletType.LEAP</code> or another supported wallet if you prefer
+          a different connector.
+        </p>
+      )}
+    </main>
+  );
+}
+
+export default function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GrazProvider
+        grazOptions={{
+          chains: [cosmoshub],
+          defaultWallet: WalletType.KEPLR,
+        }}
+      >
+        <WalletExample />
+      </GrazProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+## Try more flows
+
+- Use [Getting Started](../getting-started) for the step-by-step setup guide.
+- Use [WalletConnect](../wallet-connect) when you need QR or mobile wallet connections.
+- Use the [Playground example](https://graz.sh/examples/playground) for multi-chain connections, balances, contracts, clients, and token sends.


### PR DESCRIPTION
## Summary
- add a Try it out docs page with a minimal Vite + React + Graz example
- link the new page from the Examples overview

Closes #32

## Validation
- pnpm exec prettier --check docs/docs/examples/index.md docs/docs/examples/try-it-out.mdx
- pnpm --dir docs build

Note: the docs build still reports existing broken-anchor warnings in unrelated pages (`/docs/hooks/useAddChain` and `/docs/performance`), but completes successfully.