### PR TITLE
[codex] Fix docs broken anchors

### DIFF
--- a/docs/docs/hooks/useAddChain.md
+++ b/docs/docs/hooks/useAddChain.md
@@ -214,4 +214,4 @@ const chainInfo: ChainInfo = {
 ## See Also
 
 - [Chain Information Guide](/docs/guides/multi-chain)
-- [Adding Custom Chains](/docs/getting-started#custom-chains)
+- [Adding Custom Chains](/docs/getting-started#step-2-configure-chain-information)

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -199,7 +199,7 @@ pnpm graz dev
 
 ## Version History
 
-### v0.3.7 - Build Optimizations
+### v0.4.0 - Build Optimizations
 
 Major performance improvements:
 
@@ -208,7 +208,7 @@ Major performance improvements:
 - **72% smaller package** (800 KB → 220 KB)
 - **43% smaller TypeScript declarations** (87 KB → 49 KB)
 
-See the [changelog](./change-log.md#version-037-build-optimizations) for details.
+See the [changelog](./change-log.md#version-040-unified-multi-chain-api--performance) for details.
 
 ## Future Optimizations
 


### PR DESCRIPTION
## Summary

Fixes the recurring Docusaurus broken-anchor warnings from docs builds by updating stale docs hashes to the route targets Docusaurus actually generates.

## Root Cause

The `/docs/performance` page exists and is routed correctly, but it linked to an outdated changelog anchor: `#version-037-build-optimizations`. The current docs changelog generates `#version-040-unified-multi-chain-api--performance` instead. A second stale link in `useAddChain` pointed to a removed `#custom-chains` anchor in Getting Started.

## Changes

- Updated the `useAddChain` custom chains link to `/docs/getting-started#step-2-configure-chain-information`.
- Updated the performance page version-history heading and changelog link to match the current docs changelog target.

## Validation

- `pnpm --dir docs build`
- `pnpm --dir docs typecheck`

The docs build no longer reports broken anchors. It still prints the existing Docusaurus v4 deprecation warning for `siteConfig.onBrokenMarkdownLinks`, which is unrelated to these broken anchors.