### PR TITLE
[codex] Limit CI workflows to relevant changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ The workflows run on pinned `ubuntu-24.04` runner images and SHA-pinned actions 
 
 ### CI (`ci.yml`)
 
-Triggers on pushes and pull requests to `dev` when package, docs, example, dependency, or toolchain files change.
+Triggers on pushes and pull requests to `dev` when package, example, integration, dependency, or toolchain files change. Docs-only changes are handled by the docs workflow instead of running package CI.
 
 Jobs:
 
@@ -15,11 +15,11 @@ Jobs:
 
 ### Lint (`lint.yml`)
 
-Triggers on pushes that change source, dependency, toolchain, or lint config files. Runs `pnpm lint` with ESLint 9 flat config.
+Triggers on pushes that change package, example, integration, dependency, toolchain, or lint config files. Runs `pnpm lint` with ESLint 9 flat config.
 
 ### Docs (`docs.yml`)
 
-Deploys the Docusaurus site from `dev` or manual dispatch using GitHub Pages actions.
+Deploys the Docusaurus site from `dev` or manual dispatch using GitHub Pages actions. It runs when docs, dependency, package, or docs workflow files change.
 
 ### Playwright Integration (`integration-playwright.yml`)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
       - .github/workflows/ci.yml
       - .node-version
       - .nvmrc
-      - docs/**
       - eslint.config.mjs
       - example/**
       - integration/**
@@ -24,7 +23,6 @@ on:
       - .github/workflows/ci.yml
       - .node-version
       - .nvmrc
-      - docs/**
       - eslint.config.mjs
       - example/**
       - integration/**

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - dev
+    paths:
+      - .github/workflows/docs.yml
+      - .node-version
+      - .nvmrc
+      - docs/**
+      - package.json
+      - packages/**
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - turbo.json
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,6 @@ on:
       - .github/workflows/lint.yml
       - .node-version
       - .nvmrc
-      - docs/**
       - eslint.config.mjs
       - example/**
       - integration/**


### PR DESCRIPTION
## Summary

- stop package CI and lint workflows from running for docs-only changes
- add path filters to the docs deployment workflow so it runs only for docs, dependency, package, or docs workflow changes
- update the workflow README to document the split

## Why

Docs-only changes were treated as package CI inputs, so PRs that only touched docs still kicked off the full build/test path. This narrows each workflow to the files it actually needs to respond to.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/*.yml`