### PR TITLE
[codex] research unified wallet events RFC

### DIFF
--- a/notes/rfc/269-wallet-events-research.md
+++ b/notes/rfc/269-wallet-events-research.md
@@ -1,0 +1,279 @@
+# RFC 269: Wallet event subscriptions research
+
+Status: implementation research
+
+Issue: [graz-sh/graz#269](https://github.com/graz-sh/graz/issues/269)
+
+Researched: 2026-06-27
+
+## Recommendation
+
+Implement a smaller first version than the issue sketch:
+
+1. Add a framework-agnostic `subscribeWalletEvents()` action that returns an
+   unsubscribe function.
+2. Add a React `useWalletEvents()` hook that owns its subscription and cleanup;
+   the hook should not require callers to invoke an unsubscribe function.
+3. Support account, connected-chain-set, and disconnect events in v1.
+4. Defer `onBalanceChange`. A balance change is chain state, not a wallet event,
+   and none of Graz's wallet adapters emits it.
+5. Normalize adapter events before exposing them. Do not build the public API by
+   directly forwarding each wallet's native event.
+
+This preserves the repository boundary that actions are framework-agnostic and
+hooks wrap actions, while keeping the public behavior consistent across wallet
+implementations.
+
+## What the proposal currently says
+
+The issue proposes one hook with four callbacks:
+
+```ts
+const unsubscribe = useWalletEvents({
+  onAccountChange: (newAccount) => {},
+  onChainChange: (chainId) => {},
+  onDisconnect: () => {},
+  onBalanceChange: (balance) => {},
+});
+```
+
+The same text appeared in the now-removed
+`notes/legacy/IMPROVEMENT_DESIGN.md`. It can be recovered from the parent of
+commit `3196c98` with:
+
+```sh
+git show 3196c98^:notes/legacy/IMPROVEMENT_DESIGN.md
+```
+
+The issue and legacy note define the goal, but not event semantics, payloads,
+ordering, multi-chain behavior, or the boundary between native wallet events
+and Graz state changes.
+
+## Existing behavior in Graz
+
+### Adapter subscriptions are account-change triggers
+
+The public `Wallet` type has:
+
+```ts
+subscription?: (reconnect: () => void) => () => void;
+```
+
+Most browser adapters use it to listen for an account/keystore-change event.
+Their listeners clear the session and then invoke `reconnect`. Examples include
+Keplr, Cosmostation, Compass, Station, Vectis, XDEFI, Initia, OKX, and Cactus.
+
+WalletConnect is broader. It listens for `session_event`, `session_delete`, and
+`session_expire`; its `session_event` handler recognizes `accountsChanged` but
+otherwise falls through to reconnect.
+
+This is not yet a general event API:
+
+- the callback receives no event name or payload;
+- adapter code owns session mutation;
+- callers cannot distinguish account change from disconnect;
+- several supported wallet types are not wired in `useGrazEvents`;
+- the legacy `subscription` property is exported as part of `Wallet`, so
+  replacing its signature would be a public breaking change.
+
+### `useGrazEvents` owns native subscription lifetime, but drops cleanup
+
+`packages/graz/src/provider/events.tsx` selects an adapter from
+`_reconnectConnector` and invokes `wallet.subscription(...)` in an effect. The
+unsubscribe function returned by the adapter is not returned from the effect.
+Consequences:
+
+- unmount does not remove the native listener;
+- connector changes can leave the previous listener active;
+- effect reruns can register duplicates;
+- React Strict Mode can expose duplicate subscription behavior.
+
+The first implementation slice should add a characterization test for this
+before refactoring it.
+
+### Store state can describe public events, but not their cause
+
+`GrazSessionStore` contains:
+
+- `accounts: Record<string, Key> | null`;
+- `activeChainIds: string[] | null`;
+- `status: "connected" | "connecting" | "reconnecting" | "disconnected"`.
+
+That is enough to calculate account, chain-set, and connection diffs after an
+operation. It is not enough to infer intent. Today an adapter account-change
+listener calls `clearSession()` first, producing a temporary `disconnected`
+state before reconnecting. A store-only subscriber would therefore emit a
+false disconnect for an account switch.
+
+The implementation must either:
+
+- stop clearing session state before an account-change reconnect and emit
+  normalized events from successful actions; or
+- carry explicit event provenance through the reconciliation path.
+
+Waiting a tick and guessing whether reconnect follows is not a stable contract.
+
+### `useAccount` overlaps with two proposed callbacks
+
+`useAccount` already accepts `onConnect` and `onDisconnect` and subscribes to
+status transitions. `useWalletEvents` should not silently differ from it about
+what "disconnect" means. Long term, both hooks should consume the same
+framework-agnostic event source.
+
+### Balance has no event source
+
+`useBalance` and `useBalances` query chain RPC through a `StargateClient`.
+Their cache only changes when a query runs. Wallet keystore events do not
+contain balances, and the current adapters expose no balance event.
+
+Calling a query-cache update `onBalanceChange` would be misleading: it means
+"Graz fetched a different value," not "the chain balance changed." Detecting
+the latter needs an explicit strategy such as polling, transaction-triggered
+invalidation, or a chain-specific WebSocket/indexer subscription. That deserves
+a separate API and performance budget.
+
+## External event evidence
+
+- The [Cosmostation Cosmos event documentation](https://docs.cosmostation.io/extension/integration/cosmos/typescript)
+  describes `cosmostation_keystorechange` as an account/keystore switch signal
+  and explicitly requires removing listeners.
+- Cosmostation's
+  [wallet normalization example](https://docs.cosmostation.io/extension/integration/cosmos/wallet)
+  maps both Keplr's `keplr_keystorechange` and Leap's
+  `leap_keystorechange` to a unified `AccountChanged` event.
+- [WalletConnect session event documentation](https://docs.walletconnect.network/wallet-sdk/react-native/usage)
+  distinguishes `accountsChanged`, `chainChanged`, and `session_delete`.
+
+These sources support normalization and cleanup. They do not establish a
+portable Cosmos balance-change event.
+
+## Proposed v1 semantics
+
+### Core API
+
+```ts
+export interface WalletEventContext {
+  walletType: WalletType;
+}
+
+export interface AccountChangeEvent extends WalletEventContext {
+  accounts: Record<string, Key>;
+  previousAccounts: Record<string, Key>;
+  changedChainIds: string[];
+}
+
+export interface ChainChangeEvent extends WalletEventContext {
+  chainIds: string[];
+  previousChainIds: string[];
+  addedChainIds: string[];
+  removedChainIds: string[];
+}
+
+export interface DisconnectEvent extends WalletEventContext {
+  chainIds: string[];
+  reason: "user" | "wallet" | "session-expired" | "reconnect-failed";
+}
+
+export interface WalletEventHandlers {
+  onAccountChange?: (event: AccountChangeEvent) => void;
+  onChainChange?: (event: ChainChangeEvent) => void;
+  onDisconnect?: (event: DisconnectEvent) => void;
+}
+
+export function subscribeWalletEvents(
+  handlers: WalletEventHandlers,
+): () => void;
+```
+
+Names can be tightened during implementation, but payloads must remain
+multi-chain. A singular `chainId` or `newAccount` would contradict Graz's
+public multi-chain model.
+
+### React API
+
+```ts
+useWalletEvents({
+  onAccountChange(event) {
+    console.log(event.changedChainIds, event.accounts);
+  },
+  onChainChange(event) {
+    console.log(event.addedChainIds, event.removedChainIds);
+  },
+  onDisconnect(event) {
+    console.log(event.reason);
+  },
+});
+```
+
+The hook returns `void` and automatically unsubscribes on unmount. If an
+imperative unsubscribe is needed outside React, use
+`subscribeWalletEvents()`.
+
+### Event rules
+
+- Do not emit account or chain events for initial hydration/subscription.
+- Initial connect is a connect operation, not an account change.
+- Emit account change only after a successful wallet reconciliation and after
+  the store contains the new accounts.
+- Compare account identity per chain. For v1, `bech32Address` is the identity;
+  display-name-only changes do not count.
+- Treat `activeChainIds` as a set. Reordering alone is not a chain change.
+- Emit chain change for successful additions and partial disconnects.
+- Emit disconnect once when the final active chain is removed, a wallet session
+  is deleted/expired, or reconnect failure clears the session.
+- An account-switch reconnect must not emit disconnect.
+- Invoke handlers synchronously after the corresponding state commit.
+- One throwing consumer must not prevent other subscribers from receiving the
+  event; surface errors asynchronously or through the logger.
+- Unsubscribe must be idempotent.
+
+## Internal design
+
+Add an internal typed event channel and keep ownership clear:
+
+```text
+native wallet event
+  -> adapter normalization
+  -> account action reconciles state
+  -> action emits committed semantic event
+  -> subscribeWalletEvents()
+  -> useWalletEvents()
+```
+
+Suggested files:
+
+- `packages/graz/src/actions/events.ts` — public framework-agnostic subscribe
+  function and internal emitter;
+- `packages/graz/src/types/events.ts` — public payload and handler types;
+- `packages/graz/src/hooks/events.ts` — React lifecycle wrapper;
+- `packages/graz/src/provider/events.tsx` — native adapter orchestration only.
+
+Do not change the existing `Wallet.subscription` signature in place. Either:
+
+1. add a new optional typed adapter event source and retain `subscription` for
+   compatibility; or
+2. keep the normalization helper internal to `provider/events.tsx` while the
+   public event channel is driven by actions.
+
+The second option is the smallest v1. The first is cleaner if maintainers are
+ready to migrate every adapter in the same change.
+
+## Decisions needed before implementation
+
+1. Is `onDisconnect` full-session only? Recommended: yes; use chain change for
+   partial disconnect.
+2. Should an account event fire once with a multi-chain diff or once per chain?
+   Recommended: once with `changedChainIds`.
+3. Does initial connect count as account/chain change? Recommended: no.
+4. Is `onBalanceChange` removed from v1? Recommended: yes, with a follow-up RFC.
+5. Should reconnect failure report only disconnect or also an error event?
+   Recommended: disconnect with `reason: "reconnect-failed"` for v1.
+
+## Out of scope for v1
+
+- balance monitoring;
+- transaction events;
+- arbitrary native event passthrough;
+- changing generated `graz/chains` publishing;
+- changing signer types or deep-importing `cosmjs-types`;
+- replacing the deprecated WalletConnect modal package.

--- a/notes/rfc/269-wallet-events-research.md
+++ b/notes/rfc/269-wallet-events-research.md
@@ -14,7 +14,8 @@ Implement a smaller first version than the issue sketch:
    unsubscribe function.
 2. Add a React `useWalletEvents()` hook that owns its subscription and cleanup;
    the hook should not require callers to invoke an unsubscribe function.
-3. Support account, connected-chain-set, and disconnect events in v1.
+3. Support account, `onActiveChainsChange`, and disconnect events in v1. The
+   active-chains payload contains the complete connected `activeChainIds` set.
 4. Defer `onBalanceChange`. A balance change is chain state, not a wallet event,
    and none of Graz's wallet adapters emits it.
 5. Normalize adapter events before exposing them. Do not build the public API by
@@ -26,7 +27,8 @@ implementations.
 
 ## What the proposal currently says
 
-The issue proposes one hook with four callbacks:
+The issue proposes one hook with four callbacks. This is the original sketch,
+not the recommended v1 API:
 
 ```ts
 const unsubscribe = useWalletEvents({
@@ -48,6 +50,12 @@ git show 3196c98^:notes/legacy/IMPROVEMENT_DESIGN.md
 The issue and legacy note define the goal, but not event semantics, payloads,
 ordering, multi-chain behavior, or the boundary between native wallet events
 and Graz state changes.
+
+In particular, `onChainChange(chainId)` borrows an EVM-style active-network
+switch concept that does not fit Graz's Cosmos model. A Graz session connects
+to a set of chains simultaneously. The meaningful state is
+`GrazSessionStore.activeChainIds`, so v1 should report changes to that connected
+set rather than claim that the wallet switched to one chain.
 
 ## Existing behavior in Graz
 
@@ -162,11 +170,9 @@ export interface AccountChangeEvent extends WalletEventContext {
   changedChainIds: string[];
 }
 
-export interface ChainChangeEvent extends WalletEventContext {
-  chainIds: string[];
-  previousChainIds: string[];
-  addedChainIds: string[];
-  removedChainIds: string[];
+export interface ActiveChainsChangeEvent extends WalletEventContext {
+  activeChainIds: string[];
+  previousActiveChainIds: string[];
 }
 
 export interface DisconnectEvent extends WalletEventContext {
@@ -176,7 +182,7 @@ export interface DisconnectEvent extends WalletEventContext {
 
 export interface WalletEventHandlers {
   onAccountChange?: (event: AccountChangeEvent) => void;
-  onChainChange?: (event: ChainChangeEvent) => void;
+  onActiveChainsChange?: (event: ActiveChainsChangeEvent) => void;
   onDisconnect?: (event: DisconnectEvent) => void;
 }
 
@@ -196,8 +202,8 @@ useWalletEvents({
   onAccountChange(event) {
     console.log(event.changedChainIds, event.accounts);
   },
-  onChainChange(event) {
-    console.log(event.addedChainIds, event.removedChainIds);
+  onActiveChainsChange(event) {
+    console.log(event.activeChainIds);
   },
   onDisconnect(event) {
     console.log(event.reason);
@@ -211,14 +217,18 @@ imperative unsubscribe is needed outside React, use
 
 ### Event rules
 
-- Do not emit account or chain events for initial hydration/subscription.
+- Do not emit account or active-chains events for initial
+  hydration/subscription.
 - Initial connect is a connect operation, not an account change.
 - Emit account change only after a successful wallet reconciliation and after
   the store contains the new accounts.
 - Compare account identity per chain. For v1, `bech32Address` is the identity;
   display-name-only changes do not count.
-- Treat `activeChainIds` as a set. Reordering alone is not a chain change.
-- Emit chain change for successful additions and partial disconnects.
+- Treat `activeChainIds` as a set. Reordering alone is not a connected-chain-set
+  change.
+- Emit active-chains change for successful additions and partial disconnects.
+- Do not expose an EVM-style singular active chain or forward a wallet-native
+  `chainChanged` event as though it had that meaning in Cosmos.
 - Emit disconnect once when the final active chain is removed, a wallet session
   is deleted/expired, or reconnect failure clears the session.
 - An account-switch reconnect must not emit disconnect.
@@ -260,11 +270,11 @@ ready to migrate every adapter in the same change.
 
 ## Decisions needed before implementation
 
-1. Is `onDisconnect` full-session only? Recommended: yes; use chain change for
-   partial disconnect.
+1. Is `onDisconnect` full-session only? Recommended: yes; use
+   `onActiveChainsChange` for partial disconnect.
 2. Should an account event fire once with a multi-chain diff or once per chain?
    Recommended: once with `changedChainIds`.
-3. Does initial connect count as account/chain change? Recommended: no.
+3. Does initial connect count as account/active-chains change? Recommended: no.
 4. Is `onBalanceChange` removed from v1? Recommended: yes, with a follow-up RFC.
 5. Should reconnect failure report only disconnect or also an error event?
    Recommended: disconnect with `reason: "reconnect-failed"` for v1.

--- a/notes/rfc/269-wallet-events-tdd-plan.md
+++ b/notes/rfc/269-wallet-events-tdd-plan.md
@@ -1,0 +1,302 @@
+# RFC 269: Test-first implementation plan
+
+Companion research:
+[269-wallet-events-research.md](./269-wallet-events-research.md)
+
+## Baseline
+
+On 2026-06-27, the Graz Vitest suite passed before RFC changes:
+
+```text
+Test Files  33 passed (33)
+Tests       179 passed (179)
+```
+
+The bundled `pnpm` on PATH was `11.7.0` and was rejected by the repository's
+engine check. The passing run used the available pnpm `11.8.0` installation.
+Before implementation, make sure these report the pinned versions:
+
+```sh
+node -v   # v24.17.0
+pnpm -v   # 11.8.0
+```
+
+## TDD rules for this RFC
+
+- Work in one externally observable behavior per red-green-refactor cycle.
+- Run the narrow test file while red/green; run the full Graz checks after each
+  completed slice.
+- Test semantic events at the action boundary, not private emitter
+  implementation details.
+- Use real Zustand stores and fake wallet adapters where practical.
+- Use `vi.fn()` for event handlers and native listener spies.
+- Use `expectTypeOf` for payload contracts and public export checks.
+- Do not use snapshots for event payload behavior.
+- Every subscription test must prove cleanup.
+- Do not add `onBalanceChange` tests until a real detection mechanism and its
+  resource cost are specified.
+
+## Slice 0: Characterize current cleanup failure
+
+Target:
+`packages/graz/src/provider/__tests__/provider-events.test.tsx`
+
+Write a failing test:
+
+1. mount `GrazEvents` with a Keplr reconnect connector;
+2. spy on `window.addEventListener` and `window.removeEventListener`;
+3. verify one `keplr_keystorechange` listener is installed;
+4. unmount;
+5. expect the same listener to be removed;
+6. dispatch after unmount and prove reconnect is not called.
+
+Expected red: `useGrazEvents` currently ignores the adapter's unsubscribe
+function.
+
+Minimal green: return the adapter cleanup from the effect. Refactor the adapter
+selection only after the test passes.
+
+Also add a connector-change case: switching Keplr to another connector removes
+the Keplr listener before installing the next one.
+
+## Slice 1: Framework-agnostic subscription lifecycle
+
+Create:
+
+- `packages/graz/src/actions/events.ts`;
+- `packages/graz/src/actions/__tests__/events.test.ts`;
+- `packages/graz/src/types/events.ts`.
+
+Write failing tests in this order:
+
+1. `subscribeWalletEvents()` returns a function.
+2. A subscribed handler receives one emitted semantic event.
+3. Unsubscribed handlers receive no later events.
+4. Calling unsubscribe twice is harmless.
+5. Two subscribers both receive an event.
+6. A throwing subscriber does not block the other subscriber.
+
+Keep the internal emitter unexported from `packages/graz/src/index.ts`. Tests may
+import an explicitly named internal test seam from the module, but action tests
+in later slices should become the primary coverage.
+
+Minimal green can be a module-local `Set<WalletEventHandlers>`. Do not introduce
+an event-emitter dependency.
+
+## Slice 2: Full and partial disconnect semantics
+
+Target:
+`packages/graz/src/actions/__tests__/account.test.ts`
+
+Red tests:
+
+- full `disconnect()` emits exactly one disconnect event after the session store
+  is cleared;
+- the payload contains the wallet type, previously active chain IDs, and
+  `reason: "user"`;
+- partial disconnect emits one chain-change event with correct removed and
+  remaining chain IDs;
+- partial disconnect does not emit full disconnect while another chain remains;
+- disconnecting the final chain emits disconnect once, not both a misleading
+  chain event and a disconnect unless that dual behavior is explicitly chosen;
+- calling disconnect when already disconnected emits nothing.
+
+Minimal green: snapshot relevant pre-action state, commit existing mutations,
+then emit the semantic event. Avoid deriving the payload after the state has
+been erased.
+
+## Slice 3: Connect and account reconciliation diffs
+
+Target:
+`packages/graz/src/actions/__tests__/account.test.ts`
+
+Red tests:
+
+- initial connect emits no account-change event;
+- adding a chain to an existing session emits a chain-change event;
+- reconnect with the same addresses emits no account-change event;
+- reconnect with a changed address emits one account-change event containing
+  `previousAccounts`, `accounts`, and `changedChainIds`;
+- account comparison is per chain and independent of object identity;
+- reordering active chain IDs emits no event;
+- handlers observe the already-committed store state.
+
+Minimal green: capture a pre-operation snapshot at the start of `connect`,
+compare it with the committed result, and emit once after status becomes
+`connected`.
+
+Do not clear the existing session before account-change reconciliation. Add a
+regression test proving an account switch follows:
+
+```text
+connected -> reconnecting -> connected
+```
+
+and never exposes a false public disconnect.
+
+## Slice 4: React hook lifecycle and fresh callbacks
+
+Create:
+
+- `packages/graz/src/hooks/events.ts`;
+- `packages/graz/src/hooks/__tests__/events.test.tsx`.
+
+Use the existing local `renderHook` helper.
+
+Red tests:
+
+- the hook receives core events;
+- unmount automatically unsubscribes;
+- rerender with new callbacks calls the latest callback, not a stale closure;
+- rerender does not create a duplicate subscription;
+- omitted handlers are valid;
+- Strict Mode setup/cleanup leaves one live subscription;
+- a callback can read the committed account/session state.
+
+Recommended implementation:
+
+- keep the latest handler object in a ref;
+- install one core subscription in an effect;
+- dispatch through the ref;
+- return the core unsubscribe function from the effect;
+- return `void` from the hook.
+
+This avoids resubscribing whenever a consumer passes an inline object.
+
+## Slice 5: Native adapter normalization
+
+Targets:
+
+- `packages/graz/src/provider/events.tsx`;
+- `packages/graz/src/provider/__tests__/provider-events.test.tsx`;
+- wallet adapter tests under
+  `packages/graz/src/actions/wallet/__tests__/`.
+
+Start with Keplr, then use table-driven coverage for adapters with equivalent
+keystore events.
+
+Red tests:
+
+- a native account/keystore event reconnects and emits account change only after
+  the new key is committed;
+- it does not emit disconnect;
+- unmount removes the exact native listener;
+- connector change removes the old listener;
+- repeated effect execution does not duplicate callbacks;
+- unsupported/no-subscription adapters install nothing and do not throw.
+
+Then cover WalletConnect separately:
+
+- `accountsChanged` reconciles the affected chain and emits account change;
+- `chainChanged` has an explicitly selected meaning, or is ignored with a
+  documented reason for Cosmos multi-chain sessions;
+- `session_delete` emits disconnect with `reason: "wallet"`;
+- `session_expire` emits disconnect with `reason: "session-expired"`;
+- every `events.on` has a matching `events.off`.
+
+Refactor repeated connector `if` statements only after behavior is green. A
+map from `WalletType` to adapter getter is preferable to another expanding
+conditional block.
+
+## Slice 6: Reconnect failure
+
+Targets:
+
+- `packages/graz/src/actions/__tests__/account.test.ts`;
+- `packages/graz/src/provider/__tests__/provider-events.test.tsx`.
+
+Red tests:
+
+- failed account-change reconciliation clears the session once;
+- it emits one disconnect with `reason: "reconnect-failed"`;
+- it does not emit account change;
+- the existing `_onReconnectFailed` callback still runs;
+- native listener cleanup still occurs after failure.
+
+This test prevents `reconnect()` and `disconnect()` from double-emitting.
+Choose one layer as the owner of the final event.
+
+## Slice 7: Public API and type contract
+
+Targets:
+
+- `packages/graz/src/index.ts`;
+- `packages/graz/src/__tests__/runtime-package.test.ts`;
+- a type test under `packages/graz/src/types/__tests__/`.
+
+Red tests:
+
+- runtime package exports `subscribeWalletEvents` and `useWalletEvents`;
+- event payload types are available from `graz`;
+- `accounts` remains `Record<string, Key>`;
+- chain payloads use arrays/diffs and do not collapse to a singular chain;
+- public declarations do not add deep `cosmjs-types` imports;
+- existing action, hook, provider, wallet, type, and `graz/chains` exports remain.
+
+Add a changeset only after maintainers confirm whether this is a minor release.
+
+## Slice 8: Documentation and integration proof
+
+Update `docs/static/SKILL.md` with:
+
+- React usage through `useWalletEvents`;
+- non-React usage through `subscribeWalletEvents`;
+- exact cleanup behavior;
+- multi-chain payload examples;
+- a clear statement that balance monitoring is not included.
+
+An initial Playwright test is optional because the behavior is exhaustively
+testable with injected wallet events in jsdom. Add an E2E case only if the
+integration harness exposes a deterministic wallet account-switch control.
+Do not make CI depend on manually switching a real extension account.
+
+## Narrow commands during development
+
+```sh
+pnpm graz test -- src/actions/__tests__/events.test.ts
+pnpm graz test -- src/actions/__tests__/account.test.ts
+pnpm graz test -- src/hooks/__tests__/events.test.tsx
+pnpm graz test -- src/provider/__tests__/provider-events.test.tsx
+pnpm graz test -- src/actions/wallet/__tests__/wallet-connect.test.ts
+```
+
+Vitest may interpret arguments differently through nested pnpm scripts. If a
+command unexpectedly runs every test, invoke it from the package:
+
+```sh
+pnpm --dir packages/graz exec vitest run src/hooks/__tests__/events.test.tsx
+```
+
+## Full verification after green
+
+```sh
+pnpm graz build
+pnpm graz type-check
+pnpm graz test
+pnpm build
+pnpm lint
+pnpm --dir packages/graz pack --dry-run
+```
+
+If provider wiring or the integration fixture changes, also run:
+
+```sh
+pnpm graz cli --generate
+pnpm example:vite build
+pnpm example:playground build
+pnpm integration:test
+```
+
+## Completion checklist
+
+- [ ] Core subscription is usable without React.
+- [ ] React hook cleans up automatically.
+- [ ] No listener survives unmount or connector change.
+- [ ] Account switch never reports a false disconnect.
+- [ ] Events are emitted after committed state.
+- [ ] Multi-chain payload semantics are tested.
+- [ ] Full and partial disconnect behavior is distinct.
+- [ ] WalletConnect deletion and expiry are covered.
+- [ ] `onBalanceChange` is deferred or backed by a separately approved design.
+- [ ] Public exports and declarations remain compatible.
+- [ ] Graz build, type-check, test, lint, and package dry-run pass.

--- a/notes/rfc/269-wallet-events-tdd-plan.md
+++ b/notes/rfc/269-wallet-events-tdd-plan.md
@@ -94,11 +94,12 @@ Red tests:
   is cleared;
 - the payload contains the wallet type, previously active chain IDs, and
   `reason: "user"`;
-- partial disconnect emits one chain-change event with correct removed and
-  remaining chain IDs;
+- partial disconnect emits one active-chains-change event with the remaining
+  `activeChainIds`;
 - partial disconnect does not emit full disconnect while another chain remains;
-- disconnecting the final chain emits disconnect once, not both a misleading
-  chain event and a disconnect unless that dual behavior is explicitly chosen;
+- disconnecting the final chain emits disconnect once, not both an
+  active-chains event and a disconnect unless that dual behavior is explicitly
+  chosen;
 - calling disconnect when already disconnected emits nothing.
 
 Minimal green: snapshot relevant pre-action state, commit existing mutations,
@@ -113,7 +114,8 @@ Target:
 Red tests:
 
 - initial connect emits no account-change event;
-- adding a chain to an existing session emits a chain-change event;
+- adding a chain to an existing session emits an active-chains-change event
+  with the complete connected `activeChainIds` set;
 - reconnect with the same addresses emits no account-change event;
 - reconnect with a changed address emits one account-change event containing
   `previousAccounts`, `accounts`, and `changedChainIds`;
@@ -188,8 +190,8 @@ Red tests:
 Then cover WalletConnect separately:
 
 - `accountsChanged` reconciles the affected chain and emits account change;
-- `chainChanged` has an explicitly selected meaning, or is ignored with a
-  documented reason for Cosmos multi-chain sessions;
+- native `chainChanged` is ignored because an EVM-style active-network switch
+  does not map to Graz's Cosmos multi-chain connection set;
 - `session_delete` emits disconnect with `reason: "wallet"`;
 - `session_expire` emits disconnect with `reason: "session-expired"`;
 - every `events.on` has a matching `events.off`.
@@ -229,7 +231,8 @@ Red tests:
 - runtime package exports `subscribeWalletEvents` and `useWalletEvents`;
 - event payload types are available from `graz`;
 - `accounts` remains `Record<string, Key>`;
-- chain payloads use arrays/diffs and do not collapse to a singular chain;
+- active-chains payloads expose `activeChainIds` and do not collapse to a
+  singular active chain;
 - public declarations do not add deep `cosmjs-types` imports;
 - existing action, hook, provider, wallet, type, and `graz/chains` exports remain.
 
@@ -294,7 +297,8 @@ pnpm integration:test
 - [ ] No listener survives unmount or connector change.
 - [ ] Account switch never reports a false disconnect.
 - [ ] Events are emitted after committed state.
-- [ ] Multi-chain payload semantics are tested.
+- [ ] `onActiveChainsChange` reports the complete connected `activeChainIds`
+      set.
 - [ ] Full and partial disconnect behavior is distinct.
 - [ ] WalletConnect deletion and expiry are covered.
 - [ ] `onBalanceChange` is deferred or backed by a separately approved design.


### PR DESCRIPTION
## Summary

- document the current wallet subscription architecture and native event behavior
- propose multi-chain semantics for a framework-agnostic `subscribeWalletEvents` API and React `useWalletEvents` hook
- lay out an incremental red-green-refactor plan covering cleanup, action events, hook lifecycle, WalletConnect, types, and public exports
- explicitly defer balance-change notifications until Graz has a real chain-state detection strategy

## Why

RFC #269 establishes the desired unified API but leaves event payloads, ordering, cleanup, multi-chain behavior, and adapter normalization undefined. The repository audit also found that `useGrazEvents` currently drops adapter cleanup functions, which gives the implementation plan a concrete characterization-test starting point.

## Impact

Documentation only. This PR does not change runtime behavior or public exports. It provides implementation decisions and test cases for a follow-up TDD change.

Relates to #269.

## Validation

- `vitest run`: 33 files passed, 179 tests passed
- `git diff --check`
