### PR TITLE
[codex] add wallet event subscriptions

### DIFF
--- a/.changeset/quiet-wallet-events.md
+++ b/.changeset/quiet-wallet-events.md
@@ -1,0 +1,5 @@
+---
+"graz": minor
+---
+
+Add framework-agnostic wallet event subscriptions and the `useWalletEvents` React hook.

--- a/docs/static/SKILL.md
+++ b/docs/static/SKILL.md
@@ -194,6 +194,51 @@ import { clearSession } from "graz";
 clearSession();                            // Reset session + clear storage
 ```
 
+### Wallet Events
+
+Use `useWalletEvents` to react to committed wallet state changes. The hook owns
+its subscription and automatically cleans it up when the component unmounts.
+
+```tsx
+import { useWalletEvents } from "graz";
+
+function WalletEventObserver() {
+  useWalletEvents({
+    onAccountChange: ({ accounts, previousAccounts, changedChainIds, walletType }) => {
+      console.log({ accounts, previousAccounts, changedChainIds, walletType });
+    },
+    onActiveChainsChange: ({ activeChainIds, previousActiveChainIds, walletType }) => {
+      console.log({ activeChainIds, previousActiveChainIds, walletType });
+    },
+    onDisconnect: ({ chainIds, reason, walletType }) => {
+      console.log({ chainIds, reason, walletType });
+    },
+  });
+
+  return null;
+}
+```
+
+`onActiveChainsChange` reports the complete set of connected
+`activeChainIds`. It does not represent an EVM-style switch to one active
+chain. Initial connection does not emit account or active-chain events.
+
+For non-React consumers, subscribe imperatively and retain the cleanup
+function:
+
+```ts
+import { subscribeWalletEvents } from "graz";
+
+const unsubscribe = subscribeWalletEvents({
+  onDisconnect: ({ reason }) => console.log(reason),
+});
+
+unsubscribe();
+```
+
+Balance changes are not wallet events. Use `useBalance` or `useBalances` and an
+explicit refetch strategy when balance monitoring is required.
+
 ## Offline Signers
 
 ```ts
@@ -452,6 +497,7 @@ interface MutationEventArgs<T = unknown, S = T> {
 | Connect wallet | `useConnect()` → `connect()` |
 | Disconnect | `useDisconnect()` → `disconnect()` |
 | Account state | `useAccount({ chainId })` |
+| Wallet events | `useWalletEvents(handlers)`, `subscribeWalletEvents(handlers)` |
 | Check wallet availability | `useCheckWallet(type)`, `getAvailableWallets()` |
 | Active wallet info | `useActiveWalletType()` |
 | Offline signers | `useOfflineSigners({ chainId })` |

--- a/packages/graz/src/__tests__/runtime-package.test.ts
+++ b/packages/graz/src/__tests__/runtime-package.test.ts
@@ -23,29 +23,47 @@ describe("published package runtime shape", () => {
   it("loads the CJS entry and keeps key root exports available", () => {
     const output = runNode(`
       const graz = require("./dist/index.js");
-      const keys = ["connect", "disconnect", "useAccount", "useConnect", "WalletType"];
+      const keys = [
+        "connect",
+        "disconnect",
+        "subscribeWalletEvents",
+        "useAccount",
+        "useConnect",
+        "useWalletEvents",
+        "WalletType",
+      ];
       for (const key of keys) {
         if (!(key in graz)) throw new Error("Missing export: " + key);
       }
+      if ("disconnectWithReason" in graz) throw new Error("Internal disconnect helper was exported");
       console.log(keys.map((key) => typeof graz[key]).join(","));
     `);
 
-    expect(output.trim()).toBe("function,function,function,function,object");
+    expect(output.trim()).toBe("function,function,function,function,function,function,object");
   });
 
   it("loads the ESM entry and keeps key root exports available", () => {
     const output = runNode(`
       (async () => {
         const graz = await import("./dist/index.mjs");
-        const keys = ["connect", "disconnect", "useAccount", "useConnect", "WalletType"];
+        const keys = [
+          "connect",
+          "disconnect",
+          "subscribeWalletEvents",
+          "useAccount",
+          "useConnect",
+          "useWalletEvents",
+          "WalletType",
+        ];
         for (const key of keys) {
           if (!(key in graz)) throw new Error("Missing export: " + key);
         }
+        if ("disconnectWithReason" in graz) throw new Error("Internal disconnect helper was exported");
         console.log(keys.map((key) => typeof graz[key]).join(","));
       })();
     `);
 
-    expect(output.trim()).toBe("function,function,function,function,object");
+    expect(output.trim()).toBe("function,function,function,function,function,function,object");
   });
 
   it("does not publish generated chain indexes", () => {

--- a/packages/graz/src/__tests__/runtime-package.test.ts
+++ b/packages/graz/src/__tests__/runtime-package.test.ts
@@ -5,6 +5,94 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 const packageRoot = path.resolve(__dirname, "../..");
 const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const expectedRuntimeExports = [
+  "GrazEvents",
+  "GrazProvider",
+  "LOG_CATEGORIES",
+  "LOG_FUNCTIONS",
+  "LOG_HOOKS",
+  "LogCategory",
+  "LogLevel",
+  "WALLET_TYPES",
+  "WalletType",
+  "addChain",
+  "checkWallet",
+  "clearRecentChain",
+  "clearSession",
+  "configureGraz",
+  "configureLogger",
+  "connect",
+  "defineChainInfo",
+  "defineChains",
+  "disconnect",
+  "executeContract",
+  "getAvailableWallets",
+  "getCactusCosmos",
+  "getChainInfo",
+  "getChainInfos",
+  "getCosmostation",
+  "getKeplr",
+  "getLogger",
+  "getOfflineSigners",
+  "getOkx",
+  "getPara",
+  "getQueryRaw",
+  "getQuerySmart",
+  "getRecentChainIds",
+  "getRecentChains",
+  "getVectis",
+  "getWCCosmostation",
+  "getWCKeplr",
+  "getWallet",
+  "getWalletConnect",
+  "instantiateContract",
+  "isPara",
+  "isWalletConnect",
+  "reconnect",
+  "sendIbcTokens",
+  "sendTokens",
+  "signAndBroadcast",
+  "signArbitrary",
+  "subscribeWalletEvents",
+  "suggestChain",
+  "suggestChainAndConnect",
+  "useAccount",
+  "useActiveChainCurrency",
+  "useActiveChainIds",
+  "useActiveChains",
+  "useActiveWalletType",
+  "useAddChain",
+  "useBalance",
+  "useBalanceStaked",
+  "useBalances",
+  "useChainInfo",
+  "useChainInfos",
+  "useCheckWallet",
+  "useConnect",
+  "useCosmWasmClient",
+  "useCosmWasmSigningClient",
+  "useDisconnect",
+  "useExecuteContract",
+  "useGrazEvents",
+  "useInstantiateContract",
+  "useOfflineSigners",
+  "useQueryClientValidators",
+  "useQueryRaw",
+  "useQuerySmart",
+  "useRecentChainIds",
+  "useRecentChains",
+  "useSendIbcTokens",
+  "useSendTokens",
+  "useSignAndBroadcast",
+  "useSignArbitrary",
+  "useStargateClient",
+  "useStargateSigningClient",
+  "useSuggestChain",
+  "useSuggestChainAndConnect",
+  "useVerifyArbitrary",
+  "useWalletEvents",
+  "verifyArbitrary",
+];
 
 const runNode = (code: string) =>
   execFileSync(process.execPath, ["-e", code], {
@@ -20,50 +108,26 @@ describe("published package runtime shape", () => {
     });
   }, 120_000);
 
-  it("loads the CJS entry and keeps key root exports available", () => {
+  it("loads the CJS entry and preserves the complete runtime API", () => {
     const output = runNode(`
       const graz = require("./dist/index.js");
-      const keys = [
-        "connect",
-        "disconnect",
-        "subscribeWalletEvents",
-        "useAccount",
-        "useConnect",
-        "useWalletEvents",
-        "WalletType",
-      ];
-      for (const key of keys) {
-        if (!(key in graz)) throw new Error("Missing export: " + key);
-      }
       if ("disconnectWithReason" in graz) throw new Error("Internal disconnect helper was exported");
-      console.log(keys.map((key) => typeof graz[key]).join(","));
+      console.log(JSON.stringify(Object.keys(graz).sort()));
     `);
 
-    expect(output.trim()).toBe("function,function,function,function,function,function,object");
+    expect(JSON.parse(output)).toEqual(expectedRuntimeExports);
   });
 
-  it("loads the ESM entry and keeps key root exports available", () => {
+  it("loads the ESM entry and preserves the complete runtime API", () => {
     const output = runNode(`
       (async () => {
         const graz = await import("./dist/index.mjs");
-        const keys = [
-          "connect",
-          "disconnect",
-          "subscribeWalletEvents",
-          "useAccount",
-          "useConnect",
-          "useWalletEvents",
-          "WalletType",
-        ];
-        for (const key of keys) {
-          if (!(key in graz)) throw new Error("Missing export: " + key);
-        }
         if ("disconnectWithReason" in graz) throw new Error("Internal disconnect helper was exported");
-        console.log(keys.map((key) => typeof graz[key]).join(","));
+        console.log(JSON.stringify(Object.keys(graz).sort()));
       })();
     `);
 
-    expect(output.trim()).toBe("function,function,function,function,function,function,object");
+    expect(JSON.parse(output)).toEqual(expectedRuntimeExports);
   });
 
   it("does not publish generated chain indexes", () => {

--- a/packages/graz/src/actions/__tests__/account.test.ts
+++ b/packages/graz/src/actions/__tests__/account.test.ts
@@ -6,6 +6,7 @@ import { useGrazInternalStore, useGrazSessionStore } from "../../store";
 import type { Key } from "../../types/wallet";
 import { WalletType } from "../../types/wallet";
 import { connect, disconnect, getOfflineSigners, reconnect } from "../account";
+import { subscribeWalletEvents } from "../events";
 
 const makeKey = (chainId: string): Key => ({
   address: new Uint8Array([1, 2, 3]),
@@ -45,6 +46,8 @@ const setWindowValue = (key: string, value: unknown) => {
 };
 
 describe("account actions", () => {
+  const eventCleanups: Array<() => void> = [];
+
   beforeEach(() => {
     for (const key of ["keplr", "cosmostation"]) {
       Reflect.deleteProperty(window, key);
@@ -52,8 +55,15 @@ describe("account actions", () => {
   });
 
   afterEach(() => {
+    eventCleanups.splice(0).forEach((cleanup) => cleanup());
     vi.restoreAllMocks();
   });
+
+  const subscribe = (handlers: Parameters<typeof subscribeWalletEvents>[0]) => {
+    const cleanup = subscribeWalletEvents(handlers);
+    eventCleanups.push(cleanup);
+    return cleanup;
+  };
 
   it("connects a wallet, stores account state, and enables reconnect", async () => {
     const chain = makeChainInfo();
@@ -112,6 +122,67 @@ describe("account actions", () => {
     expect(useGrazSessionStore.getState().activeChainIds).toEqual([cosmoshub.chainId, osmosis.chainId]);
   });
 
+  it("emits committed active-chain and account changes for established sessions", async () => {
+    const cosmoshub = makeChainInfo();
+    const osmosis = makeChainInfo("osmosis-1");
+    const accounts = {
+      [cosmoshub.chainId]: makeKey(cosmoshub.chainId),
+      [osmosis.chainId]: makeKey(osmosis.chainId),
+    };
+    const wallet = makeWallet(accounts);
+    const onAccountChange = vi.fn();
+    const onActiveChainsChange = vi.fn();
+    setWindowValue("keplr", wallet);
+    useGrazInternalStore.setState({ chains: [cosmoshub, osmosis] });
+    subscribe({ onAccountChange, onActiveChainsChange });
+
+    await connect({
+      chainId: cosmoshub.chainId,
+      walletType: WalletType.KEPLR,
+    });
+
+    expect(onAccountChange).not.toHaveBeenCalled();
+    expect(onActiveChainsChange).not.toHaveBeenCalled();
+
+    await connect({
+      chainId: osmosis.chainId,
+      walletType: WalletType.KEPLR,
+    });
+
+    expect(onActiveChainsChange).toHaveBeenCalledWith({
+      activeChainIds: [cosmoshub.chainId, osmosis.chainId],
+      previousActiveChainIds: [cosmoshub.chainId],
+      walletType: WalletType.KEPLR,
+    });
+    expect(onAccountChange).not.toHaveBeenCalled();
+    expect(useGrazSessionStore.getState().activeChainIds).toEqual([cosmoshub.chainId, osmosis.chainId]);
+
+    const previousAccount = accounts[cosmoshub.chainId];
+    if (!previousAccount) throw new Error("Missing Cosmos Hub account fixture");
+    accounts[cosmoshub.chainId] = {
+      ...previousAccount,
+      bech32Address: `${cosmoshub.chainId}1changed`,
+    };
+
+    await reconnect();
+
+    expect(onAccountChange).toHaveBeenCalledWith({
+      accounts: expect.objectContaining({
+        [cosmoshub.chainId]: expect.objectContaining({
+          bech32Address: `${cosmoshub.chainId}1changed`,
+        }),
+      }),
+      changedChainIds: [cosmoshub.chainId],
+      previousAccounts: expect.objectContaining({
+        [cosmoshub.chainId]: previousAccount,
+      }),
+      walletType: WalletType.KEPLR,
+    });
+    expect(useGrazSessionStore.getState().accounts?.[cosmoshub.chainId]?.bech32Address).toBe(
+      `${cosmoshub.chainId}1changed`,
+    );
+  });
+
   it("rejects unavailable wallets and chains outside the provider config", async () => {
     const chain = makeChainInfo();
     useGrazInternalStore.setState({ chains: [chain] });
@@ -149,6 +220,9 @@ describe("account actions", () => {
       activeChainIds: [cosmoshub.chainId, osmosis.chainId],
       status: "connected",
     });
+    const onActiveChainsChange = vi.fn();
+    const onDisconnect = vi.fn();
+    subscribe({ onActiveChainsChange, onDisconnect });
 
     await disconnect({ chainId: osmosis.chainId });
 
@@ -159,6 +233,12 @@ describe("account actions", () => {
       status: "connected",
     });
     expect(useGrazInternalStore.getState().recentChainIds).toEqual([cosmoshub.chainId]);
+    expect(onActiveChainsChange).toHaveBeenCalledWith({
+      activeChainIds: [cosmoshub.chainId],
+      previousActiveChainIds: [cosmoshub.chainId, osmosis.chainId],
+      walletType: WalletType.KEPLR,
+    });
+    expect(onDisconnect).not.toHaveBeenCalled();
 
     await disconnect();
 
@@ -172,6 +252,21 @@ describe("account actions", () => {
       _reconnectConnector: null,
       recentChainIds: null,
     });
+    expect(onDisconnect).toHaveBeenCalledWith({
+      chainIds: [cosmoshub.chainId],
+      reason: "user",
+      walletType: WalletType.KEPLR,
+    });
+    expect(onActiveChainsChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not emit disconnect when the session is already disconnected", async () => {
+    const onDisconnect = vi.fn();
+    subscribe({ onDisconnect });
+
+    await disconnect();
+
+    expect(onDisconnect).not.toHaveBeenCalled();
   });
 
   it("reconnects from stored state and reports reconnect failures", async () => {
@@ -197,11 +292,18 @@ describe("account actions", () => {
       recentChainIds: [chain.chainId],
     });
     const onError = vi.fn();
+    const onDisconnect = vi.fn();
+    subscribe({ onDisconnect });
 
     await reconnect({ onError });
 
     expect(onError).toHaveBeenCalledTimes(1);
     expect(useGrazSessionStore.getState().status).toBe("disconnected");
+    expect(onDisconnect).toHaveBeenCalledWith({
+      chainIds: [chain.chainId],
+      reason: "reconnect-failed",
+      walletType: WalletType.KEPLR,
+    });
   });
 
   it("returns offline signers from the selected wallet", async () => {

--- a/packages/graz/src/actions/__tests__/events.test.ts
+++ b/packages/graz/src/actions/__tests__/events.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WalletEventHandlers } from "../../types/events";
 import type { Key } from "../../types/wallet";
 import { WalletType } from "../../types/wallet";
+import { getLogger } from "../../utils/logger";
 import { emitWalletEvent, subscribeWalletEvents } from "../events";
 
 const makeKey = (chainId: string): Key => ({
@@ -115,5 +116,36 @@ describe("wallet event subscriptions", () => {
     }).not.toThrow();
     expect(failing).toHaveBeenCalledTimes(1);
     expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs rejected async subscriber callbacks without blocking other subscribers", async () => {
+    const error = vi.spyOn(getLogger(), "error");
+    const failing = vi.fn(async () => {
+      throw new Error("async consumer failed");
+    });
+    const succeeding = vi.fn();
+    subscribe({ onDisconnect: failing });
+    subscribe({ onDisconnect: succeeding });
+
+    emitWalletEvent({
+      payload: {
+        chainIds: ["cosmoshub-4"],
+        reason: "wallet",
+        walletType: WalletType.KEPLR,
+      },
+      type: "disconnect",
+    });
+
+    expect(succeeding).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(error).toHaveBeenCalledWith(
+        expect.anything(),
+        "Wallet event subscriber failed",
+        expect.objectContaining({
+          error: "async consumer failed",
+          eventType: "disconnect",
+        }),
+      );
+    });
   });
 });

--- a/packages/graz/src/actions/__tests__/events.test.ts
+++ b/packages/graz/src/actions/__tests__/events.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { WalletEventHandlers } from "../../types/events";
+import type { Key } from "../../types/wallet";
+import { WalletType } from "../../types/wallet";
+import { emitWalletEvent, subscribeWalletEvents } from "../events";
+
+const makeKey = (chainId: string): Key => ({
+  address: new Uint8Array([1, 2, 3]),
+  algo: "secp256k1",
+  bech32Address: `${chainId}1address`,
+  isKeystone: false,
+  isNanoLedger: false,
+  name: `${chainId} account`,
+  pubKey: new Uint8Array([4, 5, 6]),
+});
+
+const cleanups: Array<() => void> = [];
+
+const subscribe = (handlers: WalletEventHandlers) => {
+  const cleanup = subscribeWalletEvents(handlers);
+  cleanups.push(cleanup);
+  return cleanup;
+};
+
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup());
+});
+
+describe("wallet event subscriptions", () => {
+  it("delivers semantic events to every subscriber", () => {
+    const chainId = "cosmoshub-4";
+    const account = makeKey(chainId);
+    const first = vi.fn();
+    const second = vi.fn();
+    subscribe({ onAccountChange: first });
+    subscribe({ onAccountChange: second });
+
+    emitWalletEvent({
+      payload: {
+        accounts: { [chainId]: account },
+        changedChainIds: [chainId],
+        previousAccounts: {
+          [chainId]: { ...account, bech32Address: `${chainId}1previous` },
+        },
+        walletType: WalletType.KEPLR,
+      },
+      type: "accountChange",
+    });
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accounts: { [chainId]: account },
+        changedChainIds: [chainId],
+      }),
+    );
+  });
+
+  it("returns an idempotent unsubscribe function", () => {
+    const onDisconnect = vi.fn();
+    const unsubscribe = subscribe({ onDisconnect });
+
+    unsubscribe();
+    unsubscribe();
+    emitWalletEvent({
+      payload: {
+        chainIds: ["cosmoshub-4"],
+        reason: "user",
+        walletType: WalletType.KEPLR,
+      },
+      type: "disconnect",
+    });
+
+    expect(onDisconnect).not.toHaveBeenCalled();
+  });
+
+  it("keeps separate subscriptions for the same handlers object", () => {
+    const onDisconnect = vi.fn();
+    const handlers = { onDisconnect };
+    const firstUnsubscribe = subscribe(handlers);
+    subscribe(handlers);
+
+    firstUnsubscribe();
+    emitWalletEvent({
+      payload: {
+        chainIds: ["cosmoshub-4"],
+        reason: "user",
+        walletType: WalletType.KEPLR,
+      },
+      type: "disconnect",
+    });
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates subscriber failures", () => {
+    const failing = vi.fn(() => {
+      throw new Error("consumer failed");
+    });
+    const succeeding = vi.fn();
+    subscribe({ onDisconnect: failing });
+    subscribe({ onDisconnect: succeeding });
+
+    expect(() => {
+      emitWalletEvent({
+        payload: {
+          chainIds: ["cosmoshub-4"],
+          reason: "wallet",
+          walletType: WalletType.KEPLR,
+        },
+        type: "disconnect",
+      });
+    }).not.toThrow();
+    expect(failing).toHaveBeenCalledTimes(1);
+    expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -366,8 +366,18 @@ export const reconnect = async (args?: ReconnectArgs) => {
         const previousAccounts = previousSession.accounts ? { ...previousSession.accounts } : null;
         const previousActiveChainIds = [...(previousSession.activeChainIds || [])];
         const wallet = getWallet(_reconnectConnector);
+        await wallet.init?.();
         await wallet.enable(recentChains);
-        useGrazSessionStore.setState({ status: "connected" });
+        useGrazInternalStore.setState({
+          _reconnect,
+          _reconnectConnector,
+          walletType: _reconnectConnector,
+        });
+        useGrazSessionStore.setState({
+          activeChainIds: [...recentChains],
+          status: "connected",
+        });
+        typeof window !== "undefined" && window.sessionStorage.setItem(RECONNECT_SESSION_KEY, "Active");
         emitConnectedSessionChanges({
           previousAccounts,
           previousActiveChainIds,

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -5,11 +5,13 @@ import type { ChainInfo } from "@keplr-wallet/types";
 import { LOG_FUNCTIONS, RECONNECT_SESSION_KEY } from "../constant";
 import { grazSessionDefaultValues, useGrazInternalStore, useGrazSessionStore } from "../store";
 import type { Maybe } from "../types/core";
+import type { DisconnectReason } from "../types/events";
 import type { Key } from "../types/wallet";
 import { WalletType } from "../types/wallet";
 import { LogCategory } from "../types/logger";
 import { getLogger } from "../utils/logger";
 import { checkWallet, getWallet, isPara, isWalletConnect } from "./wallet";
+import { emitWalletEvent } from "./events";
 
 /**
  * Chain ID type for actions - supports both string and string[] for backward compatibility.
@@ -29,10 +31,61 @@ export interface ConnectResult {
   chains: ChainInfo[];
 }
 
+const haveSameChainIds = (first: readonly string[], second: readonly string[]) => {
+  return first.length === second.length && first.every((chainId) => second.includes(chainId));
+};
+
+const emitConnectedSessionChanges = ({
+  previousAccounts,
+  previousActiveChainIds,
+  walletType,
+}: {
+  previousAccounts: Record<string, Key> | null;
+  previousActiveChainIds: string[];
+  walletType: WalletType;
+}) => {
+  const currentSession = useGrazSessionStore.getState();
+  const accounts = currentSession.accounts;
+  const activeChainIds = [...(currentSession.activeChainIds || [])];
+
+  if (!haveSameChainIds(previousActiveChainIds, activeChainIds)) {
+    emitWalletEvent({
+      payload: {
+        activeChainIds,
+        previousActiveChainIds,
+        walletType,
+      },
+      type: "activeChainsChange",
+    });
+  }
+
+  if (!previousAccounts || !accounts) return;
+  const changedChainIds = previousActiveChainIds.filter((chainId) => {
+    const previousAccount = previousAccounts[chainId];
+    const account = accounts[chainId];
+    return account !== undefined && previousAccount?.bech32Address !== account.bech32Address;
+  });
+  if (changedChainIds.length === 0) return;
+
+  emitWalletEvent({
+    payload: {
+      accounts: { ...accounts },
+      changedChainIds,
+      previousAccounts,
+      walletType,
+    },
+    type: "accountChange",
+  });
+};
+
 export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
   const logger = getLogger();
   logger.time("connect");
   logger.group("Connect Wallet");
+  const previousSession = useGrazSessionStore.getState();
+  const previousAccounts = previousSession.accounts ? { ...previousSession.accounts } : null;
+  const previousActiveChainIds = [...(previousSession.activeChainIds || [])];
+  const wasConnected = previousSession.status === "connected";
 
   try {
     const { recentChainIds: recentChains, chains, walletType } = useGrazInternalStore.getState();
@@ -130,6 +183,14 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
     const connectedChains = chainIds.map((x) => chains!.find((y) => y.chainId === x)!);
     const _resAcc = useGrazSessionStore.getState().accounts;
 
+    if (wasConnected) {
+      emitConnectedSessionChanges({
+        previousAccounts,
+        previousActiveChainIds,
+        walletType: currentWalletType,
+      });
+    }
+
     logger.info(LogCategory.WALLET, "Connection successful", {
       function: LOG_FUNCTIONS.CONNECT,
       walletType: currentWalletType,
@@ -167,9 +228,17 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
   }
 };
 
-export const disconnect = (args?: { chainId?: ActionChainId }) => {
+const disconnectSession = (
+  args: { chainId?: ActionChainId } | undefined,
+  reason: DisconnectReason,
+  disableWallet: boolean,
+) => {
   const logger = getLogger();
   const chainId = typeof args?.chainId === "string" ? [args.chainId] : args?.chainId;
+  const previousSession = useGrazSessionStore.getState();
+  const previousActiveChainIds = [...(previousSession.activeChainIds || [])];
+  const previousAccounts = previousSession.accounts ? { ...previousSession.accounts } : null;
+  const walletType = useGrazInternalStore.getState().walletType;
 
   logger.info(LogCategory.WALLET, "Disconnecting", {
     function: LOG_FUNCTIONS.DISCONNECT,
@@ -179,6 +248,7 @@ export const disconnect = (args?: { chainId?: ActionChainId }) => {
   typeof window !== "undefined" && window.sessionStorage.removeItem(RECONNECT_SESSION_KEY);
 
   const disable = () => {
+    if (!disableWallet) return;
     if (isWalletConnect(useGrazInternalStore.getState().walletType)) {
       const walletConnectInstance = getWallet(WalletType.WALLETCONNECT);
       const { disable: walletConnectDisable } = walletConnectInstance;
@@ -198,7 +268,7 @@ export const disconnect = (args?: { chainId?: ActionChainId }) => {
     }
   };
   if (chainId) {
-    const _accounts = useGrazSessionStore.getState().accounts;
+    const _accounts = previousAccounts ? { ...previousAccounts } : null;
     chainId.forEach((x) => {
       delete _accounts?.[x];
     });
@@ -233,12 +303,46 @@ export const disconnect = (args?: { chainId?: ActionChainId }) => {
     logger.debug(LogCategory.STORE, "Session cleared - disconnected from all chains", { function: LOG_FUNCTIONS.DISCONNECT });
   }
 
+  const activeChainIds = [...(useGrazSessionStore.getState().activeChainIds || [])];
+  if (previousActiveChainIds.length > 0) {
+    if (activeChainIds.length === 0) {
+      emitWalletEvent({
+        payload: {
+          chainIds: previousActiveChainIds,
+          reason,
+          walletType,
+        },
+        type: "disconnect",
+      });
+    } else if (!haveSameChainIds(previousActiveChainIds, activeChainIds)) {
+      emitWalletEvent({
+        payload: {
+          activeChainIds,
+          previousActiveChainIds,
+          walletType,
+        },
+        type: "activeChainsChange",
+      });
+    }
+  }
+
   logger.info(LogCategory.WALLET, "Disconnected successfully", {
     function: LOG_FUNCTIONS.DISCONNECT,
     chainId: chainId || "all chains",
   });
 
   return Promise.resolve();
+};
+
+export const disconnect = (args?: { chainId?: ActionChainId }) => {
+  return disconnectSession(args, "user", true);
+};
+
+export const disconnectWithReason = (
+  reason: Exclude<DisconnectReason, "user">,
+  options: { disableWallet?: boolean } = {},
+) => {
+  return disconnectSession(undefined, reason, options.disableWallet ?? false);
 };
 
 export type ReconnectArgs = Maybe<{ onError?: (error: unknown) => void }>;
@@ -257,7 +361,28 @@ export const reconnect = async (args?: ReconnectArgs) => {
     const isWalletReady = checkWallet(_reconnectConnector || undefined);
     if (recentChains && isWalletReady && _reconnectConnector) {
       const isWC = isWalletConnect(_reconnectConnector);
-      if (isWC) return;
+      if (isWC) {
+        const previousSession = useGrazSessionStore.getState();
+        const previousAccounts = previousSession.accounts ? { ...previousSession.accounts } : null;
+        const previousActiveChainIds = [...(previousSession.activeChainIds || [])];
+        const wallet = getWallet(_reconnectConnector);
+        await wallet.enable(recentChains);
+        useGrazSessionStore.setState({ status: "connected" });
+        emitConnectedSessionChanges({
+          previousAccounts,
+          previousActiveChainIds,
+          walletType: _reconnectConnector,
+        });
+        const { accounts } = useGrazSessionStore.getState();
+        const { chains } = useGrazInternalStore.getState();
+        const connectedChains =
+          chains?.filter((chain) => recentChains.includes(chain.chainId)) || [];
+        return {
+          accounts: accounts || {},
+          chains: connectedChains,
+          walletType: _reconnectConnector,
+        };
+      }
       const key = await connect({
         chainId: recentChains,
         walletType: _reconnectConnector,
@@ -279,7 +404,7 @@ export const reconnect = async (args?: ReconnectArgs) => {
       error: error instanceof Error ? error.message : String(error),
     });
     args?.onError?.(error);
-    void disconnect();
+    void disconnectSession(undefined, "reconnect-failed", true);
   }
 };
 

--- a/packages/graz/src/actions/events.ts
+++ b/packages/graz/src/actions/events.ts
@@ -1,0 +1,47 @@
+import { LogCategory } from "../types/logger";
+import type { WalletEvent, WalletEventHandlers } from "../types/events";
+import { getLogger } from "../utils/logger";
+
+interface WalletEventSubscription {
+  handlers: WalletEventHandlers;
+}
+
+const subscribers = new Set<WalletEventSubscription>();
+
+/**
+ * Subscribe to committed wallet state changes outside React.
+ *
+ * @returns An idempotent cleanup function.
+ */
+export const subscribeWalletEvents = (handlers: WalletEventHandlers): (() => void) => {
+  const subscription = { handlers };
+  subscribers.add(subscription);
+  let subscribed = true;
+
+  return () => {
+    if (!subscribed) return;
+    subscribed = false;
+    subscribers.delete(subscription);
+  };
+};
+
+/** @internal */
+export const emitWalletEvent = (event: WalletEvent): void => {
+  for (const { handlers } of [...subscribers]) {
+    try {
+      if (event.type === "accountChange") {
+        handlers.onAccountChange?.(event.payload);
+      } else if (event.type === "activeChainsChange") {
+        handlers.onActiveChainsChange?.(event.payload);
+      } else {
+        handlers.onDisconnect?.(event.payload);
+      }
+    } catch (error) {
+      getLogger().error(LogCategory.EVENT, "Wallet event subscriber failed", {
+        error: error instanceof Error ? error.message : String(error),
+        eventType: event.type,
+        function: "emitWalletEvent",
+      });
+    }
+  }
+};

--- a/packages/graz/src/actions/events.ts
+++ b/packages/graz/src/actions/events.ts
@@ -8,6 +8,30 @@ interface WalletEventSubscription {
 
 const subscribers = new Set<WalletEventSubscription>();
 
+const reportSubscriberFailure = (error: unknown, eventType: WalletEvent["type"]): void => {
+  getLogger().error(LogCategory.EVENT, "Wallet event subscriber failed", {
+    error: error instanceof Error ? error.message : String(error),
+    eventType,
+    function: "emitWalletEvent",
+  });
+};
+
+const invokeHandler = <T>(
+  handler: ((payload: T) => void | Promise<void>) | undefined,
+  payload: T,
+  eventType: WalletEvent["type"],
+): void => {
+  if (!handler) return;
+
+  try {
+    void Promise.resolve(handler(payload)).catch((error: unknown) => {
+      reportSubscriberFailure(error, eventType);
+    });
+  } catch (error) {
+    reportSubscriberFailure(error, eventType);
+  }
+};
+
 /**
  * Subscribe to committed wallet state changes outside React.
  *
@@ -28,20 +52,12 @@ export const subscribeWalletEvents = (handlers: WalletEventHandlers): (() => voi
 /** @internal */
 export const emitWalletEvent = (event: WalletEvent): void => {
   for (const { handlers } of [...subscribers]) {
-    try {
-      if (event.type === "accountChange") {
-        handlers.onAccountChange?.(event.payload);
-      } else if (event.type === "activeChainsChange") {
-        handlers.onActiveChainsChange?.(event.payload);
-      } else {
-        handlers.onDisconnect?.(event.payload);
-      }
-    } catch (error) {
-      getLogger().error(LogCategory.EVENT, "Wallet event subscriber failed", {
-        error: error instanceof Error ? error.message : String(error),
-        eventType: event.type,
-        function: "emitWalletEvent",
-      });
+    if (event.type === "accountChange") {
+      invokeHandler(handlers.onAccountChange, event.payload, event.type);
+    } else if (event.type === "activeChainsChange") {
+      invokeHandler(handlers.onActiveChainsChange, event.payload, event.type);
+    } else {
+      invokeHandler(handlers.onDisconnect, event.payload, event.type);
     }
   }
 };

--- a/packages/graz/src/actions/wallet/__tests__/browser-adapters.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/browser-adapters.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useGrazInternalStore, useGrazSessionStore } from "../../../store";
 import { WalletType } from "../../../types/wallet";
-import { checkWallet, getAvailableWallets, getWallet } from "../index";
+import { checkWallet, getAvailableWallets, getWallet, isWalletConnect } from "../index";
 import { getCactusCosmos } from "../cactus";
 import { getCompass } from "../compass";
 import { getCosmostation } from "../cosmostation";
@@ -71,6 +71,14 @@ describe("browser wallet adapters", () => {
       [WalletType.KEPLR]: true,
       [WalletType.COSMOSTATION]: false,
     });
+  });
+
+  it("recognizes every WalletConnect connector", () => {
+    expect(isWalletConnect(WalletType.WALLETCONNECT)).toBe(true);
+    expect(isWalletConnect(WalletType.WC_KEPLR_MOBILE)).toBe(true);
+    expect(isWalletConnect(WalletType.WC_COSMOSTATION_MOBILE)).toBe(true);
+    expect(isWalletConnect(WalletType.WC_CLOT_MOBILE)).toBe(true);
+    expect(isWalletConnect(WalletType.KEPLR)).toBe(false);
   });
 
   it("calls the configured not-found callback before throwing", () => {
@@ -164,7 +172,7 @@ describe("browser wallet adapters", () => {
 
     expect(xdefiWallet).toBe(xdefi);
     expect(xdefiReconnect).toHaveBeenCalledTimes(1);
-    expect(useGrazSessionStore.getState().accounts).toBeNull();
+    expect(useGrazSessionStore.getState().accounts).not.toBeNull();
     xdefiCleanup?.();
 
     const cactusSigner = {};

--- a/packages/graz/src/actions/wallet/cactus.ts
+++ b/packages/graz/src/actions/wallet/cactus.ts
@@ -3,7 +3,6 @@ import type { Keplr } from "@keplr-wallet/types";
 
 import { useGrazInternalStore } from "../../store";
 import type { Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 
 export type CactusCosmosWallet = Pick<
   Keplr,
@@ -14,10 +13,7 @@ export const getCactusCosmos = (): Wallet => {
   if (typeof window.cactuslink_cosmos !== "undefined") {
     const cactusCosmos = window.cactuslink_cosmos;
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.addEventListener("accountsChanged", listener);
       return () => {
         window.removeEventListener("accountsChanged", listener);

--- a/packages/graz/src/actions/wallet/compass.ts
+++ b/packages/graz/src/actions/wallet/compass.ts
@@ -2,7 +2,6 @@ import type { KeplrIntereactionOptions } from "@keplr-wallet/types";
 
 import { useGrazInternalStore } from "../../store";
 import type { Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 
 /**
  * Function to return Compass object (which is {@link Wallet}) and throws and error if it does not exist on `window`.
@@ -20,10 +19,7 @@ export const getCompass = (): Wallet => {
   if (typeof window.compass !== "undefined") {
     const compass = window.compass;
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.addEventListener("leap_keystorechange", listener);
       return () => {
         window.removeEventListener("leap_keystorechange", listener);

--- a/packages/graz/src/actions/wallet/cosmostation.ts
+++ b/packages/graz/src/actions/wallet/cosmostation.ts
@@ -2,7 +2,6 @@ import type { KeplrIntereactionOptions } from "@keplr-wallet/types";
 
 import { useGrazInternalStore } from "../../store";
 import type { Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 
 /**
  * Function to return cosmostation object (which is {@link Wallet}) and throws and error if it does not exist on `window`.
@@ -22,10 +21,7 @@ export const getCosmostation = (): Wallet => {
   if (typeof window.cosmostation?.providers.keplr !== "undefined") {
     const cosmostation = window.cosmostation.providers.keplr;
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.addEventListener("cosmostation_keystorechange", listener);
       return () => {
         window.removeEventListener("cosmostation_keystorechange", listener);

--- a/packages/graz/src/actions/wallet/index.ts
+++ b/packages/graz/src/actions/wallet/index.ts
@@ -133,7 +133,8 @@ export const isWalletConnect = (type: WalletType): boolean => {
   return (
     type === WalletType.WALLETCONNECT ||
     type === WalletType.WC_KEPLR_MOBILE ||
-    type === WalletType.WC_COSMOSTATION_MOBILE
+    type === WalletType.WC_COSMOSTATION_MOBILE ||
+    type === WalletType.WC_CLOT_MOBILE
   );
 };
 

--- a/packages/graz/src/actions/wallet/initia.ts
+++ b/packages/graz/src/actions/wallet/initia.ts
@@ -14,7 +14,6 @@ import type { ChainInfo } from "@keplr-wallet/types";
 
 import { useGrazInternalStore } from "../../store";
 import type { SignAminoParams, SignDirectParams, Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 
 export interface InitiaWallet {
   getVersion: () => Promise<string>;
@@ -180,10 +179,7 @@ export const getInitia = (): Wallet => {
     };
 
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.addEventListener("initia_keystorechange", listener);
       return () => {
         window.removeEventListener("initia_keystorechange", listener);

--- a/packages/graz/src/actions/wallet/keplr.ts
+++ b/packages/graz/src/actions/wallet/keplr.ts
@@ -2,7 +2,6 @@ import type { KeplrIntereactionOptions } from "@keplr-wallet/types";
 
 import { useGrazInternalStore } from "../../store";
 import type { Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 
 /**
  * Function to return {@link Wallet} object and throws and error if it does not exist on `window`.
@@ -22,10 +21,7 @@ export const getKeplr = (): Wallet => {
   if (typeof window.keplr !== "undefined") {
     const keplr = window.keplr;
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.addEventListener("keplr_keystorechange", listener);
       return () => {
         window.removeEventListener("keplr_keystorechange", listener);

--- a/packages/graz/src/actions/wallet/okx.ts
+++ b/packages/graz/src/actions/wallet/okx.ts
@@ -2,7 +2,6 @@ import type { KeplrIntereactionOptions } from "@keplr-wallet/types";
 
 import { useGrazInternalStore } from "../../store";
 import type { Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 /**
  * Function to return okxwallet object (which is {@link Wallet}) and throws and error if it does not exist on `window`.
  *
@@ -21,10 +20,7 @@ export const getOkx = (): Wallet => {
   if (typeof window.okxwallet?.keplr !== "undefined") {
     const okxWallet = window.okxwallet.keplr;
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.okxwallet?.on("accountsChanged", listener);
       return () => {
         window.okxwallet?.removeListener("accountsChanged", listener);

--- a/packages/graz/src/actions/wallet/station.ts
+++ b/packages/graz/src/actions/wallet/station.ts
@@ -3,7 +3,6 @@ import type { ChainInfo, KeplrSignOptions, StdSignDoc } from "@keplr-wallet/type
 
 import { useGrazInternalStore } from "../../store";
 import type { Key, SignDoc, Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 
 interface ChainInfoResponse {
   chainId: string;
@@ -75,10 +74,7 @@ export const getStation = (): Wallet => {
     const station = window.station.keplr;
 
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.addEventListener("station_wallet_change", listener);
       return () => {
         window.removeEventListener("station_wallet_change", listener);

--- a/packages/graz/src/actions/wallet/vectis.ts
+++ b/packages/graz/src/actions/wallet/vectis.ts
@@ -6,7 +6,6 @@ import Long from "long";
 
 import { useGrazInternalStore } from "../../store";
 import type { Key, SignAminoParams, SignDirectParams, Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 
 /**
  * Function to return {@link Wallet} object and throws and error if it does not exist on `window`.
@@ -26,10 +25,7 @@ export const getVectis = (): Wallet => {
   if (typeof window.vectis !== "undefined") {
     const vectis = window.vectis.cosmos;
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.addEventListener("vectis_accountChanged", listener);
       return () => {
         window.removeEventListener("vectis_accountChanged", listener);

--- a/packages/graz/src/actions/wallet/xdefi.ts
+++ b/packages/graz/src/actions/wallet/xdefi.ts
@@ -1,6 +1,5 @@
 import { useGrazInternalStore } from "../../store";
 import type { Wallet } from "../../types/wallet";
-import { clearSession } from ".";
 
 /**
  * Function to return xfi object (which is {@link Wallet}) and throws and error if it does not exist on `window`.
@@ -20,10 +19,7 @@ export const getXDefi = (): Wallet => {
   if (typeof window.xfi?.keplr !== "undefined") {
     const xdefi = window.xfi.keplr;
     const subscription: (reconnect: () => void) => () => void = (reconnect) => {
-      const listener = () => {
-        clearSession();
-        reconnect();
-      };
+      const listener = () => reconnect();
       window.addEventListener("keplr_keystorechange", listener);
       return () => {
         window.removeEventListener("keplr_keystorechange", listener);

--- a/packages/graz/src/hooks/__tests__/events.test.tsx
+++ b/packages/graz/src/hooks/__tests__/events.test.tsx
@@ -1,0 +1,74 @@
+import { StrictMode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { emitWalletEvent } from "../../actions/events";
+import { renderComponent, renderHook } from "../../__tests__/react";
+import { WalletType } from "../../types/wallet";
+import { useWalletEvents } from "../events";
+
+const emitDisconnect = () => {
+  emitWalletEvent({
+    payload: {
+      chainIds: ["cosmoshub-4"],
+      reason: "wallet",
+      walletType: WalletType.KEPLR,
+    },
+    type: "disconnect",
+  });
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useWalletEvents", () => {
+  it("uses the latest callbacks without duplicating subscriptions", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    let onDisconnect = first;
+    const rendered = renderHook(() => useWalletEvents({ onDisconnect }));
+
+    onDisconnect = second;
+    rendered.rerender();
+    emitDisconnect();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    rendered.unmount();
+  });
+
+  it("automatically unsubscribes on unmount", () => {
+    const onDisconnect = vi.fn();
+    const rendered = renderHook(() => useWalletEvents({ onDisconnect }));
+
+    rendered.unmount();
+    emitDisconnect();
+
+    expect(onDisconnect).not.toHaveBeenCalled();
+  });
+
+  it("keeps one live subscription in Strict Mode", () => {
+    const onDisconnect = vi.fn();
+    const Host = () => {
+      useWalletEvents({ onDisconnect });
+      return null;
+    };
+    const rendered = renderComponent(
+      <StrictMode>
+        <Host />
+      </StrictMode>,
+    );
+
+    emitDisconnect();
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    rendered.unmount();
+  });
+
+  it("accepts omitted handlers", () => {
+    const rendered = renderHook(() => useWalletEvents());
+
+    expect(() => emitDisconnect()).not.toThrow();
+    rendered.unmount();
+  });
+});

--- a/packages/graz/src/hooks/events.ts
+++ b/packages/graz/src/hooks/events.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+
+import { subscribeWalletEvents } from "../actions/events";
+import type { WalletEventHandlers } from "../types/events";
+
+/**
+ * Subscribe to committed wallet state changes for the lifetime of a React
+ * component.
+ */
+export const useWalletEvents = (handlers: WalletEventHandlers = {}): void => {
+  const handlersRef = useRef(handlers);
+
+  useEffect(() => {
+    handlersRef.current = handlers;
+  }, [handlers]);
+
+  useEffect(() => {
+    return subscribeWalletEvents({
+      onAccountChange: (event) => handlersRef.current.onAccountChange?.(event),
+      onActiveChainsChange: (event) => handlersRef.current.onActiveChainsChange?.(event),
+      onDisconnect: (event) => handlersRef.current.onDisconnect?.(event),
+    });
+  }, []);
+};

--- a/packages/graz/src/hooks/events.ts
+++ b/packages/graz/src/hooks/events.ts
@@ -1,7 +1,9 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 import { subscribeWalletEvents } from "../actions/events";
 import type { WalletEventHandlers } from "../types/events";
+
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 /**
  * Subscribe to committed wallet state changes for the lifetime of a React
@@ -10,7 +12,7 @@ import type { WalletEventHandlers } from "../types/events";
 export const useWalletEvents = (handlers: WalletEventHandlers = {}): void => {
   const handlersRef = useRef(handlers);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     handlersRef.current = handlers;
   }, [handlers]);
 

--- a/packages/graz/src/index.ts
+++ b/packages/graz/src/index.ts
@@ -1,6 +1,14 @@
-export * from "./actions/account";
+export { connect, disconnect, getOfflineSigners, reconnect } from "./actions/account";
+export type {
+  ActionChainId,
+  ConnectArgs,
+  ConnectResult,
+  OfflineSigners,
+  ReconnectArgs,
+} from "./actions/account";
 export * from "./actions/chains";
 export * from "./actions/configure";
+export { subscribeWalletEvents } from "./actions/events";
 export * from "./actions/methods";
 export * from "./actions/wallet";
 export { LOG_CATEGORIES, LOG_FUNCTIONS, LOG_HOOKS } from "./constant";
@@ -19,11 +27,20 @@ export * from "./chains";
 export * from "./hooks/account";
 export * from "./hooks/chains";
 export * from "./hooks/clients";
+export { useWalletEvents } from "./hooks/events";
 export * from "./hooks/methods";
 export * from "./hooks/signingClients";
 export * from "./hooks/wallet";
 export * from "./provider";
 export * from "./provider/events";
 export * from "./types/core";
+export type {
+  AccountChangeEvent,
+  ActiveChainsChangeEvent,
+  DisconnectEvent,
+  DisconnectReason,
+  WalletEventContext,
+  WalletEventHandlers,
+} from "./types/events";
 export * from "./types/para";
 export * from "./types/wallet";

--- a/packages/graz/src/provider/__tests__/provider-events.test.tsx
+++ b/packages/graz/src/provider/__tests__/provider-events.test.tsx
@@ -307,6 +307,15 @@ describe("provider components and events", () => {
             expiry: Math.floor(Date.now() / 1000) + 60,
             requiredNamespaces: {
               cosmos: {
+                chains: ["cosmos:osmosis-1"],
+              },
+            },
+            topic: "unrelated-topic",
+          },
+          {
+            expiry: Math.floor(Date.now() / 1000) + 60,
+            requiredNamespaces: {
+              cosmos: {
                 chains: [`cosmos:${chain.chainId}`],
               },
             },
@@ -341,7 +350,7 @@ describe("provider components and events", () => {
           projectId: "project-id",
         },
       },
-      walletType: WalletType.WALLETCONNECT,
+      walletType: WalletType.KEPLR,
     });
     useGrazSessionStore.setState({
       accounts: { [chain.chainId]: previousAccount },
@@ -356,6 +365,7 @@ describe("provider components and events", () => {
 
     await act(async () => {
       signClient.events.emit("session_event", {
+        id: 1,
         params: {
           chainId: `cosmos:${chain.chainId}`,
           event: {
@@ -363,10 +373,26 @@ describe("provider components and events", () => {
             name: "accountsChanged",
           },
         },
+        topic: "unrelated-topic",
       });
       await Promise.resolve();
     });
+    expect(onAccountChange).not.toHaveBeenCalled();
 
+    await act(async () => {
+      signClient.events.emit("session_event", {
+        id: 2,
+        params: {
+          chainId: `cosmos:${chain.chainId}`,
+          event: {
+            data: [bech32Address],
+            name: "accountsChanged",
+          },
+        },
+        topic: "topic-1",
+      });
+      await Promise.resolve();
+    });
     await vi.waitFor(() => {
       expect(onAccountChange).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -375,10 +401,13 @@ describe("provider components and events", () => {
       );
     });
     expect(onDisconnect).not.toHaveBeenCalled();
+    expect(useGrazInternalStore.getState().walletType).toBe(WalletType.WALLETCONNECT);
+    expect(window.sessionStorage.getItem(RECONNECT_SESSION_KEY)).toBe("Active");
 
     bech32Address = `${chain.chainId}1ignored`;
     await act(async () => {
       signClient.events.emit("session_event", {
+        id: 3,
         params: {
           chainId: `cosmos:${chain.chainId}`,
           event: {
@@ -386,16 +415,30 @@ describe("provider components and events", () => {
             name: "chainChanged",
           },
         },
+        topic: "topic-1",
       });
       await Promise.resolve();
     });
     expect(onAccountChange).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      signClient.events.emit(sessionEvent);
+      signClient.events.emit(
+        sessionEvent,
+        sessionEvent === "session_delete"
+          ? { id: 4, topic: "unrelated-topic" }
+          : { topic: "unrelated-topic" },
+      );
       await Promise.resolve();
     });
+    expect(onDisconnect).not.toHaveBeenCalled();
 
+    await act(async () => {
+      signClient.events.emit(
+        sessionEvent,
+        sessionEvent === "session_delete" ? { id: 5, topic: "topic-1" } : { topic: "topic-1" },
+      );
+      await Promise.resolve();
+    });
     expect(onDisconnect).toHaveBeenCalledWith({
       chainIds: [chain.chainId],
       reason: disconnectReason,

--- a/packages/graz/src/provider/__tests__/provider-events.test.tsx
+++ b/packages/graz/src/provider/__tests__/provider-events.test.tsx
@@ -1,6 +1,8 @@
 import { act } from "react";
+import type { ISignClient } from "@walletconnect/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { subscribeWalletEvents } from "../../actions/events";
 import { makeChainInfo } from "../../__tests__/fixtures";
 import { flushReact, renderComponent } from "../../__tests__/react";
 import { RECONNECT_SESSION_KEY } from "../../constant";
@@ -41,13 +43,23 @@ const setWindowValue = (key: string, value: unknown) => {
 };
 
 describe("provider components and events", () => {
+  const eventCleanups: Array<() => void> = [];
+
   beforeEach(() => {
+    Reflect.deleteProperty(window, "cactuslink_cosmos");
     Reflect.deleteProperty(window, "keplr");
   });
 
   afterEach(() => {
+    eventCleanups.splice(0).forEach((cleanup) => cleanup());
     vi.restoreAllMocks();
   });
+
+  const subscribe = (handlers: Parameters<typeof subscribeWalletEvents>[0]) => {
+    const cleanup = subscribeWalletEvents(handlers);
+    eventCleanups.push(cleanup);
+    return cleanup;
+  };
 
   it("hydrates client-only children and configures GrazProvider options", async () => {
     const chain = makeChainInfo();
@@ -217,5 +229,265 @@ describe("provider components and events", () => {
       status: "connected",
     });
     rendered.unmount();
+  });
+
+  it("emits an account change without a transient disconnect", async () => {
+    const chain = makeChainInfo();
+    const previousAccount = makeKey(chain.chainId);
+    const account = {
+      ...previousAccount,
+      bech32Address: `${chain.chainId}1changed`,
+    };
+    const wallet = makeWallet(account);
+    const onAccountChange = vi.fn();
+    const onDisconnect = vi.fn();
+    setWindowValue("keplr", wallet);
+    useGrazInternalStore.setState({
+      _reconnect: false,
+      _reconnectConnector: WalletType.KEPLR,
+      chains: [chain],
+      recentChainIds: [chain.chainId],
+      walletType: WalletType.KEPLR,
+    });
+    useGrazSessionStore.setState({
+      accounts: { [chain.chainId]: previousAccount },
+      activeChainIds: [chain.chainId],
+      status: "connected",
+    });
+    subscribe({ onAccountChange, onDisconnect });
+
+    const rendered = renderComponent(<GrazEvents />);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("keplr_keystorechange"));
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(onAccountChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          changedChainIds: [chain.chainId],
+        }),
+      );
+    });
+    expect(onDisconnect).not.toHaveBeenCalled();
+    expect(useGrazSessionStore.getState()).toMatchObject({
+      accounts: { [chain.chainId]: account },
+      activeChainIds: [chain.chainId],
+      status: "connected",
+    });
+    rendered.unmount();
+  });
+
+  it.each([
+    ["session_delete", "wallet"],
+    ["session_expire", "session-expired"],
+  ] as const)("normalizes WalletConnect account and %s events", async (sessionEvent, disconnectReason) => {
+    const chain = makeChainInfo();
+    const previousAccount = makeKey(chain.chainId);
+    const listeners = new Map<string, Set<(args?: unknown) => void>>();
+    let bech32Address = `${chain.chainId}1changed`;
+    const signClient = {
+      events: {
+        emit: (event: string, args?: unknown) => {
+          listeners.get(event)?.forEach((listener) => listener(args));
+        },
+        off: vi.fn((event: string, listener: (args?: unknown) => void) => {
+          listeners.get(event)?.delete(listener);
+        }),
+        on: vi.fn((event: string, listener: (args?: unknown) => void) => {
+          const eventListeners = listeners.get(event) ?? new Set();
+          eventListeners.add(listener);
+          listeners.set(event, eventListeners);
+        }),
+      },
+      session: {
+        getAll: vi.fn(() => [
+          {
+            expiry: Math.floor(Date.now() / 1000) + 60,
+            requiredNamespaces: {
+              cosmos: {
+                chains: [`cosmos:${chain.chainId}`],
+              },
+            },
+            sessionProperties: {
+              keys: JSON.stringify([
+                {
+                  ...previousAccount,
+                  address: Array.from(previousAccount.address),
+                  bech32Address,
+                  chainId: chain.chainId,
+                  pubKey: Buffer.from(previousAccount.pubKey).toString("base64"),
+                },
+              ]),
+            },
+            topic: "topic-1",
+          },
+        ]),
+      },
+    };
+    const wcSignClients = new Map<WalletType, ISignClient>([
+      [WalletType.WALLETCONNECT, signClient as unknown as ISignClient],
+    ]);
+    const onAccountChange = vi.fn();
+    const onDisconnect = vi.fn();
+    useGrazInternalStore.setState({
+      _reconnect: false,
+      _reconnectConnector: WalletType.WALLETCONNECT,
+      chains: [chain],
+      recentChainIds: [chain.chainId],
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+      walletType: WalletType.WALLETCONNECT,
+    });
+    useGrazSessionStore.setState({
+      accounts: { [chain.chainId]: previousAccount },
+      activeChainIds: [chain.chainId],
+      status: "connected",
+      wcSignClients,
+    });
+    subscribe({ onAccountChange, onDisconnect });
+
+    const rendered = renderComponent(<GrazEvents />);
+    await flushReact();
+
+    await act(async () => {
+      signClient.events.emit("session_event", {
+        params: {
+          chainId: `cosmos:${chain.chainId}`,
+          event: {
+            data: [bech32Address],
+            name: "accountsChanged",
+          },
+        },
+      });
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(onAccountChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          changedChainIds: [chain.chainId],
+        }),
+      );
+    });
+    expect(onDisconnect).not.toHaveBeenCalled();
+
+    bech32Address = `${chain.chainId}1ignored`;
+    await act(async () => {
+      signClient.events.emit("session_event", {
+        params: {
+          chainId: `cosmos:${chain.chainId}`,
+          event: {
+            data: chain.chainId,
+            name: "chainChanged",
+          },
+        },
+      });
+      await Promise.resolve();
+    });
+    expect(onAccountChange).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      signClient.events.emit(sessionEvent);
+      await Promise.resolve();
+    });
+
+    expect(onDisconnect).toHaveBeenCalledWith({
+      chainIds: [chain.chainId],
+      reason: disconnectReason,
+      walletType: WalletType.WALLETCONNECT,
+    });
+    expect(useGrazSessionStore.getState()).toMatchObject({
+      accounts: null,
+      activeChainIds: null,
+      status: "disconnected",
+    });
+    rendered.unmount();
+    expect(signClient.events.off).toHaveBeenCalledWith("session_event", expect.any(Function));
+  });
+
+  it("removes the wallet account-change listener on unmount", async () => {
+    const chain = makeChainInfo();
+    const account = makeKey(chain.chainId);
+    const wallet = makeWallet(account);
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+    setWindowValue("keplr", wallet);
+    useGrazInternalStore.setState({
+      _reconnect: false,
+      _reconnectConnector: WalletType.KEPLR,
+      chains: [chain],
+      recentChainIds: [chain.chainId],
+      walletType: WalletType.KEPLR,
+    });
+
+    const rendered = renderComponent(<GrazEvents />);
+    await flushReact();
+    const subscriptions = addEventListener.mock.calls.filter(([event]) => event === "keplr_keystorechange");
+
+    expect(subscriptions.length).toBeGreaterThan(0);
+    rendered.unmount();
+
+    expect(
+      subscriptions.every(([, listener]) =>
+        removeEventListener.mock.calls.some(
+          ([event, removedListener]) => event === "keplr_keystorechange" && removedListener === listener,
+        ),
+      ),
+    ).toBe(true);
+    wallet.enable.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("keplr_keystorechange"));
+      await Promise.resolve();
+    });
+
+    expect(wallet.enable).not.toHaveBeenCalled();
+  });
+
+  it("replaces the wallet listener when the connector changes", async () => {
+    const chain = makeChainInfo();
+    const account = makeKey(chain.chainId);
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+    setWindowValue("keplr", makeWallet(account));
+    setWindowValue("cactuslink_cosmos", makeWallet(account));
+    useGrazInternalStore.setState({
+      _reconnect: false,
+      _reconnectConnector: WalletType.KEPLR,
+      chains: [chain],
+      recentChainIds: [chain.chainId],
+      walletType: WalletType.KEPLR,
+    });
+
+    const rendered = renderComponent(<GrazEvents />);
+    await flushReact();
+    const keplrSubscriptions = addEventListener.mock.calls.filter(
+      ([event]) => event === "keplr_keystorechange",
+    );
+
+    await act(async () => {
+      useGrazInternalStore.setState({
+        _reconnectConnector: WalletType.CACTUSCOSMOS,
+        walletType: WalletType.CACTUSCOSMOS,
+      });
+      await Promise.resolve();
+    });
+
+    expect(
+      keplrSubscriptions.every(([, listener]) =>
+        removeEventListener.mock.calls.some(
+          ([event, removedListener]) => event === "keplr_keystorechange" && removedListener === listener,
+        ),
+      ),
+    ).toBe(true);
+    expect(addEventListener).toHaveBeenCalledWith("accountsChanged", expect.any(Function));
+
+    rendered.unmount();
+    expect(removeEventListener).toHaveBeenCalledWith("accountsChanged", expect.any(Function));
   });
 });

--- a/packages/graz/src/provider/events.tsx
+++ b/packages/graz/src/provider/events.tsx
@@ -124,18 +124,47 @@ export const useGrazEvents = () => {
       const signClient = wcSignClients.get(_reconnectConnector);
       if (!signClient) return;
 
+      const isActiveSessionTopic = (topic: string): boolean => {
+        const { activeChainIds } = useGrazSessionStore.getState();
+        const { recentChainIds } = useGrazInternalStore.getState();
+        const connectedChainIds = activeChainIds || recentChainIds || [];
+        const sessions = signClient.session.getAll();
+        const activeSession =
+          connectedChainIds.length > 0
+            ? [...sessions].reverse().find((session) => {
+                const namespace = session.namespaces?.cosmos;
+                const sessionChainIds = [
+                  ...(session.requiredNamespaces.cosmos?.chains || []),
+                  ...(namespace?.chains || []),
+                  ...(namespace?.accounts || []).map((account) =>
+                    account.split(":").slice(0, 2).join(":"),
+                  ),
+                ].map((chainId) => chainId.split(":")[1]);
+
+                return connectedChainIds.some((chainId) => sessionChainIds.includes(chainId));
+              })
+            : sessions.at(-1);
+
+        return activeSession?.topic === topic;
+      };
       const handleSessionEvent = (args: SignClientTypes.EventArguments["session_event"]) => {
+        if (!isActiveSessionTopic(args.topic)) return;
         if (args.params.event.name !== "accountsChanged") return;
         void reconnect({ onError: _onReconnectFailed });
       };
-      const handleDisconnect = (reason: "wallet" | "session-expired") => {
+      const handleDisconnect = (topic: string, reason: "wallet" | "session-expired") => {
+        if (!isActiveSessionTopic(topic)) return;
         const clients = new Map(useGrazSessionStore.getState().wcSignClients);
         clients.delete(_reconnectConnector);
         useGrazSessionStore.setState({ wcSignClients: clients });
         void disconnectWithReason(reason);
       };
-      const handleSessionDelete = () => handleDisconnect("wallet");
-      const handleSessionExpire = () => handleDisconnect("session-expired");
+      const handleSessionDelete = (args: SignClientTypes.EventArguments["session_delete"]) => {
+        handleDisconnect(args.topic, "wallet");
+      };
+      const handleSessionExpire = (args: SignClientTypes.EventArguments["session_expire"]) => {
+        handleDisconnect(args.topic, "session-expired");
+      };
 
       signClient.events.on("session_delete", handleSessionDelete);
       signClient.events.on("session_expire", handleSessionExpire);

--- a/packages/graz/src/provider/events.tsx
+++ b/packages/graz/src/provider/events.tsx
@@ -1,20 +1,12 @@
 import { Cosmiframe } from "@dao-dao/cosmiframe";
+import type { SignClientTypes } from "@walletconnect/types";
 import type { FC } from "react";
 import { useEffect } from "react";
 
-import { connect, reconnect } from "../actions/account";
-import { checkWallet, getWallet } from "../actions/wallet";
+import { connect, disconnectWithReason, reconnect } from "../actions/account";
+import { checkWallet, getWallet, isWalletConnect } from "../actions/wallet";
 import { LogCategory } from "../types/logger";
 import { getLogger } from "../utils/logger";
-import { getCompass } from "../actions/wallet/compass";
-import { getCosmiframe } from "../actions/wallet/cosmiframe";
-import { getCosmostation } from "../actions/wallet/cosmostation";
-import { getKeplr } from "../actions/wallet/keplr";
-import { getOkx } from "../actions/wallet/okx";
-import { getStation } from "../actions/wallet/station";
-import { getVectis } from "../actions/wallet/vectis";
-import { getWalletConnect } from "../actions/wallet/wallet-connect";
-import { getXDefi } from "../actions/wallet/xdefi";
 import { RECONNECT_SESSION_KEY } from "../constant";
 import { useGrazInternalStore, useGrazSessionStore } from "../store";
 import { WalletType } from "../types/wallet";
@@ -68,7 +60,16 @@ export const useGrazEvents = () => {
     return () => {
       window.removeEventListener("focus", handleFocus);
     };
-  }, [isSessionActive, isReconnectConnectorReady, _reconnectConnector, chains, activeChains, pingInterval]);
+  }, [
+    _onReconnectFailed,
+    activeChains,
+    chains,
+    isReconnectConnectorReady,
+    isSessionActive,
+    logger,
+    pingInterval,
+    _reconnectConnector,
+  ]);
 
   // Auto connect to iframe if possible.
   useEffect(() => {
@@ -117,63 +118,46 @@ export const useGrazEvents = () => {
   }, [isReconnectConnectorReady]);
 
   useEffect(() => {
-    if (_reconnectConnector) {
-      if (!isReconnectConnectorReady) return;
-      if (_reconnectConnector === WalletType.COSMOSTATION) {
-        getCosmostation().subscription?.(() => {
-          logger.debug(LogCategory.EVENT, "Account changed", { function: "subscription", walletType: WalletType.COSMOSTATION });
-          void reconnect({
-            onError: _onReconnectFailed,
-          });
-        });
-      }
-      if (_reconnectConnector === WalletType.KEPLR) {
-        getKeplr().subscription?.(() => {
-          logger.debug(LogCategory.EVENT, "Account changed", { function: "subscription", walletType: WalletType.KEPLR });
-          void reconnect({ onError: _onReconnectFailed });
-        });
-      }
-      if (_reconnectConnector === WalletType.COMPASS) {
-        getCompass().subscription?.(() => {
-          void reconnect({ onError: _onReconnectFailed });
-        });
-      }
-      if (_reconnectConnector === WalletType.VECTIS) {
-        getVectis().subscription?.(() => {
-          void reconnect({ onError: _onReconnectFailed });
-        });
-      }
-      if (_reconnectConnector === WalletType.WALLETCONNECT) {
-        if (wcSignClients.has(WalletType.WALLETCONNECT)) {
-          getWalletConnect().subscription?.(() => {
-            void reconnect({ onError: _onReconnectFailed });
-          });
-        }
-      }
-      if (_reconnectConnector === WalletType.STATION) {
-        getStation().subscription?.(() => {
-          void reconnect({ onError: _onReconnectFailed });
-        });
-      }
-      if (_reconnectConnector === WalletType.XDEFI) {
-        getXDefi().subscription?.(() => {
-          void reconnect({ onError: _onReconnectFailed });
-        });
-      }
-      if (_reconnectConnector === WalletType.COSMIFRAME) {
-        getCosmiframe().subscription?.(() => {
-          void reconnect({ onError: _onReconnectFailed });
-        });
-      }
-      if (_reconnectConnector === WalletType.OKX) {
-        getOkx().subscription?.(() => {
-          void reconnect({ onError: _onReconnectFailed });
-        });
-      }
+    if (!_reconnectConnector || !isReconnectConnectorReady) return;
+
+    if (isWalletConnect(_reconnectConnector)) {
+      const signClient = wcSignClients.get(_reconnectConnector);
+      if (!signClient) return;
+
+      const handleSessionEvent = (args: SignClientTypes.EventArguments["session_event"]) => {
+        if (args.params.event.name !== "accountsChanged") return;
+        void reconnect({ onError: _onReconnectFailed });
+      };
+      const handleDisconnect = (reason: "wallet" | "session-expired") => {
+        const clients = new Map(useGrazSessionStore.getState().wcSignClients);
+        clients.delete(_reconnectConnector);
+        useGrazSessionStore.setState({ wcSignClients: clients });
+        void disconnectWithReason(reason);
+      };
+      const handleSessionDelete = () => handleDisconnect("wallet");
+      const handleSessionExpire = () => handleDisconnect("session-expired");
+
+      signClient.events.on("session_delete", handleSessionDelete);
+      signClient.events.on("session_expire", handleSessionExpire);
+      signClient.events.on("session_event", handleSessionEvent);
+
+      return () => {
+        signClient.events.off("session_delete", handleSessionDelete);
+        signClient.events.off("session_expire", handleSessionExpire);
+        signClient.events.off("session_event", handleSessionEvent);
+      };
     }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [_reconnectConnector, wcSignClients, isReconnectConnectorReady]);
+    const wallet = getWallet(_reconnectConnector);
+    return wallet.subscription?.(() => {
+      logger.debug(LogCategory.EVENT, "Account changed", {
+        function: "subscription",
+        walletType: _reconnectConnector,
+      });
+      void reconnect({ onError: _onReconnectFailed });
+    });
+
+  }, [_onReconnectFailed, _reconnectConnector, isReconnectConnectorReady, logger, wcSignClients]);
 
   return null;
 };

--- a/packages/graz/src/types/__tests__/wallet-events.test.ts
+++ b/packages/graz/src/types/__tests__/wallet-events.test.ts
@@ -1,0 +1,40 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type {
+  AccountChangeEvent,
+  ActiveChainsChangeEvent,
+  DisconnectEvent,
+  WalletEventHandlers,
+} from "../../index";
+import type { Key } from "../wallet";
+import { WalletType } from "../wallet";
+
+describe("wallet event public types", () => {
+  it("uses multi-chain account and active-chain payloads", () => {
+    expectTypeOf<AccountChangeEvent["accounts"]>().toEqualTypeOf<Record<string, Key>>();
+    expectTypeOf<AccountChangeEvent["changedChainIds"]>().toEqualTypeOf<string[]>();
+    expectTypeOf<ActiveChainsChangeEvent["activeChainIds"]>().toEqualTypeOf<string[]>();
+    expectTypeOf<ActiveChainsChangeEvent["previousActiveChainIds"]>().toEqualTypeOf<string[]>();
+  });
+
+  it("exposes typed handlers and disconnect reasons", () => {
+    const handlers: WalletEventHandlers = {
+      onActiveChainsChange: (event) => {
+        expectTypeOf(event.activeChainIds).toEqualTypeOf<string[]>();
+      },
+      onDisconnect: (event) => {
+        expectTypeOf(event.reason).toEqualTypeOf<
+          "user" | "wallet" | "session-expired" | "reconnect-failed"
+        >();
+      },
+    };
+    const event: DisconnectEvent = {
+      chainIds: ["cosmoshub-4"],
+      reason: "wallet",
+      walletType: WalletType.KEPLR,
+    };
+
+    expectTypeOf(handlers).toMatchTypeOf<WalletEventHandlers>();
+    expectTypeOf(event.walletType).toEqualTypeOf<WalletType>();
+  });
+});

--- a/packages/graz/src/types/events.ts
+++ b/packages/graz/src/types/events.ts
@@ -29,9 +29,9 @@ export interface DisconnectEvent extends WalletEventContext {
 
 /** Callbacks accepted by wallet event subscriptions. */
 export interface WalletEventHandlers {
-  onAccountChange?: (event: AccountChangeEvent) => void;
-  onActiveChainsChange?: (event: ActiveChainsChangeEvent) => void;
-  onDisconnect?: (event: DisconnectEvent) => void;
+  onAccountChange?: (event: AccountChangeEvent) => void | Promise<void>;
+  onActiveChainsChange?: (event: ActiveChainsChangeEvent) => void | Promise<void>;
+  onDisconnect?: (event: DisconnectEvent) => void | Promise<void>;
 }
 
 /** @internal Semantic event used to dispatch committed wallet state changes. */

--- a/packages/graz/src/types/events.ts
+++ b/packages/graz/src/types/events.ts
@@ -1,0 +1,41 @@
+import type { Key, WalletType } from "./wallet";
+
+/** Context shared by every normalized wallet event. */
+export interface WalletEventContext {
+  walletType: WalletType;
+}
+
+/** Account identities after a wallet account switch. */
+export interface AccountChangeEvent extends WalletEventContext {
+  accounts: Record<string, Key>;
+  previousAccounts: Record<string, Key>;
+  changedChainIds: string[];
+}
+
+/** The complete connected chain set after it changes. */
+export interface ActiveChainsChangeEvent extends WalletEventContext {
+  activeChainIds: string[];
+  previousActiveChainIds: string[];
+}
+
+/** Why Graz cleared the complete wallet session. */
+export type DisconnectReason = "user" | "wallet" | "session-expired" | "reconnect-failed";
+
+/** Details for a full-session disconnect. */
+export interface DisconnectEvent extends WalletEventContext {
+  chainIds: string[];
+  reason: DisconnectReason;
+}
+
+/** Callbacks accepted by wallet event subscriptions. */
+export interface WalletEventHandlers {
+  onAccountChange?: (event: AccountChangeEvent) => void;
+  onActiveChainsChange?: (event: ActiveChainsChangeEvent) => void;
+  onDisconnect?: (event: DisconnectEvent) => void;
+}
+
+/** @internal Semantic event used to dispatch committed wallet state changes. */
+export type WalletEvent =
+  | { type: "accountChange"; payload: AccountChangeEvent }
+  | { type: "activeChainsChange"; payload: ActiveChainsChangeEvent }
+  | { type: "disconnect"; payload: DisconnectEvent };


### PR DESCRIPTION
## Summary

- add framework-agnostic `subscribeWalletEvents` and React `useWalletEvents` APIs
- model Cosmos wallet state as account changes, active connected chain IDs, and disconnect reasons
- normalize browser-wallet and WalletConnect subscriptions with deterministic listener cleanup
- add public exports, integration guidance, a minor changeset, and TDD coverage

## Why

RFC #269 has been accepted. Graz previously handled wallet notifications inside the provider without a public subscription API. Provider subscriptions also discarded adapter cleanup functions, and several adapters cleared session state before reconnection completed, which could surface transient false disconnects.

This implementation keeps actions framework-agnostic, wraps the subscription action for React, and uses active chain IDs rather than EVM-style chain-switch semantics.

## Developer impact

Consumers can subscribe imperatively with `subscribeWalletEvents` or declaratively with `useWalletEvents`. Events cover account identity changes, changes to the active connected-chain set, and full disconnects with normalized reasons. Balance-change events remain outside this RFC.

## Validation

- `corepack pnpm --dir packages/graz test` — 197 tests passed
- `corepack pnpm --dir packages/graz type-check`
- `corepack pnpm --dir packages/graz build`
- `corepack pnpm build`
- `corepack pnpm lint`
- `corepack pnpm --dir packages/graz cli --generate`
- `corepack pnpm --dir example/vite build`
- `corepack pnpm --dir example/playground build`
- `corepack pnpm --dir integration/playwright test:e2e` — 5 tests passed
- `corepack pnpm --dir packages/graz pack --dry-run --json`

Closes #269