### PR TITLE
fix(walletconnect): resolve connections from approved optional scope

### DIFF
--- a/.changeset/approved-walletconnect-scope.md
+++ b/.changeset/approved-walletconnect-scope.md
@@ -1,0 +1,5 @@
+---
+"graz": patch
+---
+
+Connect WalletConnect sessions with the wallet-approved subset of optional Cosmos chains.

--- a/.changeset/approved-walletconnect-scope.md
+++ b/.changeset/approved-walletconnect-scope.md
@@ -1,5 +1,7 @@
 ---
-"graz": patch
+"graz": minor
 ---
 
-Connect WalletConnect sessions with the wallet-approved subset of optional Cosmos chains.
+Allow WalletConnect `connect()` and `reconnect()` to succeed with the wallet-approved subset of optional Cosmos chains configured in `GrazProvider`.
+
+**Breaking change:** Successful connections may omit requested chains. Applications must check the returned `accounts[chainId]` for each chain required by their operation before proceeding. Public TypeScript signatures remain unchanged.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,9 +25,12 @@ Deploys the Docusaurus site from `dev` or manual dispatch using GitHub Pages act
 
 Runs a purpose-built browser integration harness for `graz` on `dev` pushes, PRs targeting `dev`, nightly schedule, or manual dispatch. It uses the protected `graz-integration` environment and a Keplr-compatible test wallet injected by Playwright.
 
-Required environment secret:
+Optional wallet override for trusted runs:
 
 - `GRAZ_E2E_WALLET_MNEMONIC`: burner testnet wallet mnemonic.
+- `GRAZ_E2E_EXPECTED_ADDRESS`: address derived from the burner mnemonic.
+
+When the secret is unavailable, including on pull requests from forks, the workflow falls back to a public, unfunded disposable mnemonic and its matching address.
 
 Optional environment secret:
 
@@ -43,7 +46,6 @@ Environment variables:
 - `GRAZ_E2E_DENOM`
 - `GRAZ_E2E_DISPLAY_DENOM`
 - `GRAZ_E2E_GAS_PRICE`
-- `GRAZ_E2E_EXPECTED_ADDRESS` (optional)
 - `GRAZ_E2E_ENABLE_TX` (optional, defaults to disabled)
 - `GRAZ_E2E_RECIPIENT_ADDRESS` (optional, required only when tx tests are enabled)
 
@@ -55,10 +57,12 @@ ENV=graz-integration
 
 gh api --method PUT "repos/$REPO/environments/$ENV"
 
+# Optional trusted-run wallet override. Set its matching expected address as a pair.
 read -rsp "Testnet mnemonic: " GRAZ_E2E_WALLET_MNEMONIC; echo
 printf '%s' "$GRAZ_E2E_WALLET_MNEMONIC" \
   | gh secret set GRAZ_E2E_WALLET_MNEMONIC --repo "$REPO" --env "$ENV"
 unset GRAZ_E2E_WALLET_MNEMONIC
+gh variable set GRAZ_E2E_EXPECTED_ADDRESS --repo "$REPO" --env "$ENV" --body "<matching-address>"
 
 gh variable set GRAZ_E2E_CHAIN_ID --repo "$REPO" --env "$ENV" --body "cosmoshub-4"
 gh variable set GRAZ_E2E_CHAIN_NAME --repo "$REPO" --env "$ENV" --body "Cosmos Hub"
@@ -69,7 +73,7 @@ gh variable set GRAZ_E2E_DENOM --repo "$REPO" --env "$ENV" --body "uatom"
 gh variable set GRAZ_E2E_DISPLAY_DENOM --repo "$REPO" --env "$ENV" --body "ATOM"
 gh variable set GRAZ_E2E_GAS_PRICE --repo "$REPO" --env "$ENV" --body "0.025"
 gh variable set GRAZ_E2E_ENABLE_TX --repo "$REPO" --env "$ENV" --body "0"
-# Optional: set GRAZ_E2E_EXPECTED_ADDRESS and GRAZ_E2E_RECIPIENT_ADDRESS when needed.
+# Optional: set GRAZ_E2E_RECIPIENT_ADDRESS when transaction tests are enabled.
 ```
 
 ### Publish (`publish.yml`)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,7 +36,7 @@ Optional environment secret:
 
 - `GRAZ_E2E_RPC_HEADERS_JSON`: JSON object with RPC headers for private/authenticated endpoints.
 
-Environment variables:
+Optional chain configuration overrides:
 
 - `GRAZ_E2E_CHAIN_ID`
 - `GRAZ_E2E_CHAIN_NAME`
@@ -48,6 +48,8 @@ Environment variables:
 - `GRAZ_E2E_GAS_PRICE`
 - `GRAZ_E2E_ENABLE_TX` (optional, defaults to disabled)
 - `GRAZ_E2E_RECIPIENT_ADDRESS` (optional, required only when tx tests are enabled)
+
+When these overrides are unavailable, including on pull requests from forks, the workflow uses the public Cosmos Hub defaults shown in the setup example below.
 
 Setup pattern:
 

--- a/.github/workflows/integration-playwright.yml
+++ b/.github/workflows/integration-playwright.yml
@@ -48,16 +48,16 @@ jobs:
       CI: true
       GRAZ_E2E_WALLET_MNEMONIC: ${{ secrets.GRAZ_E2E_WALLET_MNEMONIC || 'test test test test test test test test test test test junk' }}
       GRAZ_E2E_RPC_HEADERS_JSON: ${{ secrets.GRAZ_E2E_RPC_HEADERS_JSON }}
-      GRAZ_E2E_CHAIN_ID: ${{ vars.GRAZ_E2E_CHAIN_ID }}
-      GRAZ_E2E_CHAIN_NAME: ${{ vars.GRAZ_E2E_CHAIN_NAME }}
-      GRAZ_E2E_RPC_URL: ${{ vars.GRAZ_E2E_RPC_URL }}
-      GRAZ_E2E_REST_URL: ${{ vars.GRAZ_E2E_REST_URL }}
-      GRAZ_E2E_BECH32_PREFIX: ${{ vars.GRAZ_E2E_BECH32_PREFIX }}
-      GRAZ_E2E_DENOM: ${{ vars.GRAZ_E2E_DENOM }}
-      GRAZ_E2E_DISPLAY_DENOM: ${{ vars.GRAZ_E2E_DISPLAY_DENOM }}
-      GRAZ_E2E_GAS_PRICE: ${{ vars.GRAZ_E2E_GAS_PRICE }}
+      GRAZ_E2E_CHAIN_ID: ${{ vars.GRAZ_E2E_CHAIN_ID || 'cosmoshub-4' }}
+      GRAZ_E2E_CHAIN_NAME: ${{ vars.GRAZ_E2E_CHAIN_NAME || 'Cosmos Hub' }}
+      GRAZ_E2E_RPC_URL: ${{ vars.GRAZ_E2E_RPC_URL || 'https://cosmos-rpc.publicnode.com' }}
+      GRAZ_E2E_REST_URL: ${{ vars.GRAZ_E2E_REST_URL || 'https://rest.cosmos.directory/cosmoshub' }}
+      GRAZ_E2E_BECH32_PREFIX: ${{ vars.GRAZ_E2E_BECH32_PREFIX || 'cosmos' }}
+      GRAZ_E2E_DENOM: ${{ vars.GRAZ_E2E_DENOM || 'uatom' }}
+      GRAZ_E2E_DISPLAY_DENOM: ${{ vars.GRAZ_E2E_DISPLAY_DENOM || 'ATOM' }}
+      GRAZ_E2E_GAS_PRICE: ${{ vars.GRAZ_E2E_GAS_PRICE || '0.025' }}
       GRAZ_E2E_EXPECTED_ADDRESS: ${{ secrets.GRAZ_E2E_WALLET_MNEMONIC && vars.GRAZ_E2E_EXPECTED_ADDRESS || 'cosmos15yk64u7zc9g9k2yr2wmzeva5qgwxps6yxj00e7' }}
-      GRAZ_E2E_ENABLE_TX: ${{ vars.GRAZ_E2E_ENABLE_TX }}
+      GRAZ_E2E_ENABLE_TX: ${{ vars.GRAZ_E2E_ENABLE_TX || '0' }}
       GRAZ_E2E_RECIPIENT_ADDRESS: ${{ vars.GRAZ_E2E_RECIPIENT_ADDRESS }}
 
     steps:

--- a/.github/workflows/integration-playwright.yml
+++ b/.github/workflows/integration-playwright.yml
@@ -46,7 +46,7 @@ jobs:
     environment: graz-integration
     env:
       CI: true
-      GRAZ_E2E_WALLET_MNEMONIC: ${{ secrets.GRAZ_E2E_WALLET_MNEMONIC }}
+      GRAZ_E2E_WALLET_MNEMONIC: ${{ secrets.GRAZ_E2E_WALLET_MNEMONIC || 'test test test test test test test test test test test junk' }}
       GRAZ_E2E_RPC_HEADERS_JSON: ${{ secrets.GRAZ_E2E_RPC_HEADERS_JSON }}
       GRAZ_E2E_CHAIN_ID: ${{ vars.GRAZ_E2E_CHAIN_ID }}
       GRAZ_E2E_CHAIN_NAME: ${{ vars.GRAZ_E2E_CHAIN_NAME }}
@@ -56,7 +56,7 @@ jobs:
       GRAZ_E2E_DENOM: ${{ vars.GRAZ_E2E_DENOM }}
       GRAZ_E2E_DISPLAY_DENOM: ${{ vars.GRAZ_E2E_DISPLAY_DENOM }}
       GRAZ_E2E_GAS_PRICE: ${{ vars.GRAZ_E2E_GAS_PRICE }}
-      GRAZ_E2E_EXPECTED_ADDRESS: ${{ vars.GRAZ_E2E_EXPECTED_ADDRESS }}
+      GRAZ_E2E_EXPECTED_ADDRESS: ${{ secrets.GRAZ_E2E_WALLET_MNEMONIC && vars.GRAZ_E2E_EXPECTED_ADDRESS || 'cosmos15yk64u7zc9g9k2yr2wmzeva5qgwxps6yxj00e7' }}
       GRAZ_E2E_ENABLE_TX: ${{ vars.GRAZ_E2E_ENABLE_TX }}
       GRAZ_E2E_RECIPIENT_ADDRESS: ${{ vars.GRAZ_E2E_RECIPIENT_ADDRESS }}
 

--- a/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
+++ b/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
@@ -120,6 +120,69 @@ describe("WalletConnect account action", () => {
     ]);
   });
 
+  it("reconciles existing chains with the approved session scope", async () => {
+    const chainA = makeChainInfo("cosmoshub-4");
+    const chainB = makeChainInfo("osmosis-1");
+    const chainC = makeChainInfo("juno-1");
+    const chainD = makeChainInfo("neutron-1");
+    const accountA = makeKey(chainA.chainId);
+    const accountB = makeKey(chainB.chainId);
+    const accountC = makeKey(chainC.chainId);
+    const accountD = makeKey(chainD.chainId);
+    const session = {
+      expiry: Math.floor(Date.now() / 1000) + 60,
+      namespaces: {
+        cosmos: {
+          accounts: [
+            `cosmos:${chainA.chainId}:${accountA.bech32Address}`,
+            `cosmos:${chainD.chainId}:${accountD.bech32Address}`,
+          ],
+          events: [],
+          methods: [],
+        },
+      },
+      topic: "topic-1",
+    };
+    const signClient = {
+      session: {
+        getAll: vi.fn(() => [session]),
+      },
+    };
+
+    walletMock.enable.mockImplementation(async () => {
+      useGrazSessionStore.setState({
+        accounts: {
+          [chainC.chainId]: accountC,
+          [chainA.chainId]: accountA,
+          [chainD.chainId]: accountD,
+        },
+        wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+      });
+    });
+    useGrazInternalStore.setState({
+      chains: [chainA, chainB, chainC, chainD],
+      recentChainIds: [chainB.chainId, chainC.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    useGrazSessionStore.setState({
+      accounts: {
+        [chainB.chainId]: accountB,
+        [chainC.chainId]: accountC,
+      },
+      activeChainIds: [chainB.chainId, chainC.chainId],
+      status: "connected",
+    });
+
+    const result = await connect({
+      chainId: [chainB.chainId, chainA.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+
+    expect(result.chains).toEqual([chainA, chainD]);
+    expect(useGrazSessionStore.getState().activeChainIds).toEqual([chainC.chainId, chainA.chainId, chainD.chainId]);
+    expect(useGrazInternalStore.getState().recentChainIds).toEqual([chainC.chainId, chainA.chainId, chainD.chainId]);
+  });
+
   it("reconnects with the latest approved configured scope", async () => {
     const chainA = makeChainInfo("cosmoshub-4");
     const omitted = makeChainInfo("osmosis-1");

--- a/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
+++ b/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
@@ -40,7 +40,7 @@ describe("WalletConnect account action", () => {
     walletMock.init.mockReset().mockResolvedValue(undefined);
   });
 
-  it("stores all active approved chains while returning the current resolved scope", async () => {
+  it("replaces active chains with the approved scope in requested and configured order", async () => {
     const chainA = makeChainInfo("cosmoshub-4");
     const chainB = makeChainInfo("osmosis-1");
     const chainC = makeChainInfo("juno-1");
@@ -73,7 +73,6 @@ describe("WalletConnect account action", () => {
     walletMock.enable.mockImplementation(async () => {
       useGrazSessionStore.setState({
         accounts: {
-          [chainC.chainId]: accountC,
           [chainA.chainId]: accountA,
           [chainB.chainId]: accountB,
           [chainD.chainId]: accountD,
@@ -98,7 +97,6 @@ describe("WalletConnect account action", () => {
 
     expect(result).toEqual({
       accounts: {
-        [chainC.chainId]: accountC,
         [chainA.chainId]: accountA,
         [chainB.chainId]: accountB,
         [chainD.chainId]: accountD,
@@ -107,20 +105,18 @@ describe("WalletConnect account action", () => {
       walletType: WalletType.WALLETCONNECT,
     });
     expect(useGrazSessionStore.getState().activeChainIds).toEqual([
-      chainC.chainId,
       chainB.chainId,
       chainA.chainId,
       chainD.chainId,
     ]);
     expect(useGrazInternalStore.getState().recentChainIds).toEqual([
-      chainC.chainId,
       chainB.chainId,
       chainA.chainId,
       chainD.chainId,
     ]);
   });
 
-  it("reconciles existing chains with the approved session scope", async () => {
+  it("drops previous chains absent from the approved session even when not requested", async () => {
     const chainA = makeChainInfo("cosmoshub-4");
     const chainB = makeChainInfo("osmosis-1");
     const chainC = makeChainInfo("juno-1");
@@ -152,7 +148,6 @@ describe("WalletConnect account action", () => {
     walletMock.enable.mockImplementation(async () => {
       useGrazSessionStore.setState({
         accounts: {
-          [chainC.chainId]: accountC,
           [chainA.chainId]: accountA,
           [chainD.chainId]: accountD,
         },
@@ -179,8 +174,9 @@ describe("WalletConnect account action", () => {
     });
 
     expect(result.chains).toEqual([chainA, chainD]);
-    expect(useGrazSessionStore.getState().activeChainIds).toEqual([chainC.chainId, chainA.chainId, chainD.chainId]);
-    expect(useGrazInternalStore.getState().recentChainIds).toEqual([chainC.chainId, chainA.chainId, chainD.chainId]);
+    expect(result.accounts).toEqual({ [chainA.chainId]: accountA, [chainD.chainId]: accountD });
+    expect(useGrazSessionStore.getState().activeChainIds).toEqual([chainA.chainId, chainD.chainId]);
+    expect(useGrazInternalStore.getState().recentChainIds).toEqual([chainA.chainId, chainD.chainId]);
   });
 
   it("reconnects with the latest approved configured scope", async () => {

--- a/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
+++ b/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const walletMock = vi.hoisted(() => ({
+  disable: vi.fn().mockResolvedValue(undefined),
+  enable: vi.fn(),
+  init: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../wallet", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../wallet")>();
+  return {
+    ...original,
+    checkWallet: vi.fn(() => true),
+    getWallet: vi.fn(() => walletMock),
+    isPara: vi.fn(() => false),
+    isWalletConnect: vi.fn((walletType) => walletType === "walletconnect"),
+  };
+});
+
+import { makeChainInfo } from "../../__tests__/fixtures";
+import { useGrazInternalStore, useGrazSessionStore } from "../../store";
+import type { Key } from "../../types/wallet";
+import { WalletType } from "../../types/wallet";
+import { connect, reconnect } from "../account";
+
+const makeKey = (chainId: string): Key => ({
+  address: new Uint8Array([1, 2, 3]),
+  algo: "secp256k1",
+  bech32Address: `${chainId}1address`,
+  isKeystone: false,
+  isNanoLedger: false,
+  name: `${chainId} account`,
+  pubKey: new Uint8Array([4, 5, 6]),
+});
+
+describe("WalletConnect account action", () => {
+  beforeEach(() => {
+    walletMock.disable.mockReset().mockResolvedValue(undefined);
+    walletMock.enable.mockReset();
+    walletMock.init.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("stores all active approved chains while returning the current resolved scope", async () => {
+    const chainA = makeChainInfo("cosmoshub-4");
+    const chainB = makeChainInfo("osmosis-1");
+    const chainC = makeChainInfo("juno-1");
+    const chainD = makeChainInfo("neutron-1");
+    const accountA = makeKey(chainA.chainId);
+    const accountB = makeKey(chainB.chainId);
+    const accountC = makeKey(chainC.chainId);
+    const accountD = makeKey(chainD.chainId);
+    const session = {
+      expiry: Math.floor(Date.now() / 1000) + 60,
+      namespaces: {
+        cosmos: {
+          accounts: [
+            `cosmos:${chainA.chainId}:${accountA.bech32Address}`,
+            `cosmos:${chainB.chainId}:${accountB.bech32Address}`,
+            `cosmos:${chainD.chainId}:${accountD.bech32Address}`,
+          ],
+          events: [],
+          methods: [],
+        },
+      },
+      topic: "topic-1",
+    };
+    const signClient = {
+      session: {
+        getAll: vi.fn(() => [session]),
+      },
+    };
+
+    walletMock.enable.mockImplementation(async () => {
+      useGrazSessionStore.setState({
+        accounts: {
+          [chainC.chainId]: accountC,
+          [chainA.chainId]: accountA,
+          [chainB.chainId]: accountB,
+          [chainD.chainId]: accountD,
+        },
+        wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+      });
+    });
+    useGrazInternalStore.setState({
+      chains: [chainA, chainB, chainD, chainC],
+      recentChainIds: [chainC.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    useGrazSessionStore.setState({
+      accounts: { [chainC.chainId]: accountC },
+      activeChainIds: [chainC.chainId],
+    });
+
+    const result = await connect({
+      chainId: [chainB.chainId, chainA.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+
+    expect(result).toEqual({
+      accounts: {
+        [chainC.chainId]: accountC,
+        [chainA.chainId]: accountA,
+        [chainB.chainId]: accountB,
+        [chainD.chainId]: accountD,
+      },
+      chains: [chainB, chainA, chainD],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    expect(useGrazSessionStore.getState().activeChainIds).toEqual([
+      chainC.chainId,
+      chainB.chainId,
+      chainA.chainId,
+      chainD.chainId,
+    ]);
+    expect(useGrazInternalStore.getState().recentChainIds).toEqual([
+      chainC.chainId,
+      chainB.chainId,
+      chainA.chainId,
+      chainD.chainId,
+    ]);
+  });
+
+  it("reconnects with the latest approved configured scope", async () => {
+    const chainA = makeChainInfo("cosmoshub-4");
+    const omitted = makeChainInfo("osmosis-1");
+    const additional = makeChainInfo("neutron-1");
+    const accountA = makeKey(chainA.chainId);
+    const accountD = makeKey(additional.chainId);
+    const session = {
+      expiry: Math.floor(Date.now() / 1000) + 60,
+      namespaces: {
+        cosmos: {
+          accounts: [
+            `cosmos:${chainA.chainId}:${accountA.bech32Address}`,
+            `cosmos:${additional.chainId}:${accountD.bech32Address}`,
+          ],
+          events: [],
+          methods: [],
+        },
+      },
+      topic: "topic-1",
+    };
+    const signClient = {
+      session: {
+        getAll: vi.fn(() => [session]),
+      },
+    };
+
+    walletMock.enable.mockImplementation(async () => {
+      useGrazSessionStore.setState({
+        accounts: {
+          [chainA.chainId]: accountA,
+          [additional.chainId]: accountD,
+        },
+        wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+      });
+    });
+    useGrazInternalStore.setState({
+      _reconnect: true,
+      _reconnectConnector: WalletType.WALLETCONNECT,
+      chains: [chainA, omitted, additional],
+      recentChainIds: [chainA.chainId, omitted.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    useGrazSessionStore.setState({ accounts: null, activeChainIds: null });
+
+    await expect(reconnect()).resolves.toEqual({
+      accounts: {
+        [chainA.chainId]: accountA,
+        [additional.chainId]: accountD,
+      },
+      chains: [chainA, additional],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    expect(walletMock.enable).toHaveBeenCalledWith([chainA.chainId, omitted.chainId]);
+    expect(useGrazSessionStore.getState().activeChainIds).toEqual([chainA.chainId, additional.chainId]);
+    expect(useGrazInternalStore.getState().recentChainIds).toEqual([chainA.chainId, additional.chainId]);
+  });
+});

--- a/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
+++ b/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
@@ -295,4 +295,60 @@ describe("WalletConnect account action", () => {
     expect(calls).toEqual(["disable:start", "disable:end", "enable"]);
     expect(useGrazSessionStore.getState().wcSignClients.get(WalletType.WALLETCONNECT)).toBe(signClient);
   });
+
+  it("does not retain connected state when a replacement session fails", async () => {
+    const chain = makeChainInfo("cosmoshub-4");
+    const account = makeKey(chain.chainId);
+    const signClient = { session: { getAll: vi.fn(() => []) } };
+    walletMock.enable.mockRejectedValue(new Error("User closed wallet connect"));
+    useGrazInternalStore.setState({
+      chains: [chain],
+      recentChainIds: [chain.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    useGrazSessionStore.setState({
+      accounts: { [chain.chainId]: account },
+      activeChainIds: [chain.chainId],
+      status: "connected",
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(connect({ chainId: chain.chainId, walletType: WalletType.WALLETCONNECT })).rejects.toThrow(
+      "User closed wallet connect",
+    );
+
+    expect(walletMock.disable).toHaveBeenCalledTimes(1);
+    expect(useGrazSessionStore.getState()).toMatchObject({
+      accounts: null,
+      activeChainIds: null,
+      status: "disconnected",
+    });
+    expect(useGrazSessionStore.getState().wcSignClients.get(WalletType.WALLETCONNECT)).toBe(signClient);
+  });
+
+  it("validates requested chains before disconnecting the current session", async () => {
+    const chain = makeChainInfo("cosmoshub-4");
+    const account = makeKey(chain.chainId);
+    useGrazInternalStore.setState({
+      chains: [chain],
+      recentChainIds: [chain.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    useGrazSessionStore.setState({
+      accounts: { [chain.chainId]: account },
+      activeChainIds: [chain.chainId],
+      status: "connected",
+    });
+
+    await expect(connect({ chainId: "unknown-chain", walletType: WalletType.WALLETCONNECT })).rejects.toThrow(
+      "Chain unknown-chain is not provided in GrazProvider",
+    );
+
+    expect(walletMock.disable).not.toHaveBeenCalled();
+    expect(useGrazSessionStore.getState()).toMatchObject({
+      accounts: { [chain.chainId]: account },
+      activeChainIds: [chain.chainId],
+      status: "connected",
+    });
+  });
 });

--- a/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
+++ b/packages/graz/src/actions/__tests__/wallet-connect-account.test.ts
@@ -239,4 +239,64 @@ describe("WalletConnect account action", () => {
     expect(useGrazSessionStore.getState().activeChainIds).toEqual([chainA.chainId, additional.chainId]);
     expect(useGrazInternalStore.getState().recentChainIds).toEqual([chainA.chainId, additional.chainId]);
   });
+
+  it("finishes the previous disconnect before enabling a new session", async () => {
+    const chain = makeChainInfo("cosmoshub-4");
+    const account = makeKey(chain.chainId);
+    const calls: string[] = [];
+    let resolveDisconnect!: () => void;
+    const disconnecting = new Promise<void>((resolve) => {
+      resolveDisconnect = resolve;
+    });
+    const session = {
+      expiry: Math.floor(Date.now() / 1000) + 60,
+      namespaces: {
+        cosmos: {
+          accounts: [`cosmos:${chain.chainId}:${account.bech32Address}`],
+          events: [],
+          methods: [],
+        },
+      },
+      topic: "new-topic",
+    };
+    const signClient = {
+      session: {
+        getAll: vi.fn(() => [session]),
+      },
+    };
+    walletMock.disable.mockImplementation(async () => {
+      calls.push("disable:start");
+      await disconnecting;
+      calls.push("disable:end");
+      useGrazSessionStore.setState({ wcSignClients: new Map() });
+    });
+    walletMock.enable.mockImplementation(async () => {
+      calls.push("enable");
+      useGrazSessionStore.setState({
+        accounts: { [chain.chainId]: account },
+        wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+      });
+    });
+    useGrazInternalStore.setState({
+      chains: [chain],
+      recentChainIds: [chain.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    useGrazSessionStore.setState({
+      accounts: { [chain.chainId]: account },
+      activeChainIds: [chain.chainId],
+      status: "connected",
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const connection = connect({ chainId: chain.chainId, walletType: WalletType.WALLETCONNECT });
+    await vi.waitFor(() => expect(walletMock.disable).toHaveBeenCalledTimes(1));
+    expect(walletMock.enable).not.toHaveBeenCalled();
+
+    resolveDisconnect();
+    await expect(connection).resolves.toMatchObject({ walletType: WalletType.WALLETCONNECT });
+
+    expect(calls).toEqual(["disable:start", "disable:end", "enable"]);
+    expect(useGrazSessionStore.getState().wcSignClients.get(WalletType.WALLETCONNECT)).toBe(signClient);
+  });
 });

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -11,7 +11,7 @@ import { WalletType } from "../types/wallet";
 import { LogCategory } from "../types/logger";
 import { getLogger } from "../utils/logger";
 import { checkWallet, getWallet, isPara, isWalletConnect } from "./wallet";
-import { resolveSession } from "./wallet/wallet-connect/approved-session";
+import { resolveApprovedChainIds, resolveSession } from "./wallet/wallet-connect/approved-session";
 import { emitWalletEvent } from "./events";
 
 /**
@@ -47,15 +47,11 @@ const getWalletConnectResolvedChainIds = (
   const resolved = resolveSession(signClient.session.getAll().at(-1));
   if (!resolved) throw new Error("No approved WalletConnect accounts");
 
-  const configuredChainIds = chains.map((chain) => chain.chainId);
-  const approvedChainIds = new Set(resolved.scope.chainIds);
-  const requested = requestedChainIds.filter(
-    (chainId) => approvedChainIds.has(chainId) && configuredChainIds.includes(chainId),
+  const resolvedChainIds = resolveApprovedChainIds(
+    resolved.scope,
+    requestedChainIds,
+    chains.map((chain) => chain.chainId),
   );
-  const additional = configuredChainIds.filter(
-    (chainId) => approvedChainIds.has(chainId) && !requested.includes(chainId),
-  );
-  const resolvedChainIds = [...requested, ...additional];
   if (resolvedChainIds.length === 0) throw new Error("No approved WalletConnect accounts for configured chains");
 
   return resolvedChainIds;

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -57,11 +57,6 @@ const getWalletConnectResolvedChainIds = (
   return resolvedChainIds;
 };
 
-const reconcileChainIds = (current: string[] | null, requested: string[], resolved: string[]) =>
-  [...(current || []).filter((chainId) => !requested.includes(chainId)), ...resolved].filter(
-    (chainId, index, chainIds) => chainIds.indexOf(chainId) === index,
-  );
-
 const getConnectedChains = (chainIds: string[], chains: ChainInfo[]) =>
   chainIds.map((chainId) => {
     const chain = chains.find((candidate) => candidate.chainId === chainId);
@@ -198,12 +193,12 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
 
     useGrazInternalStore.setState((prev) => ({
       recentChainIds: isWalletConnect(currentWalletType)
-        ? reconcileChainIds(prev.recentChainIds, chainIds, resolvedChainIds)
+        ? resolvedChainIds
         : [...(prev.recentChainIds || []), ...chainIds].filter((thing, i, arr) => arr.indexOf(thing) === i),
     }));
     useGrazSessionStore.setState((prev) => ({
       activeChainIds: isWalletConnect(currentWalletType)
-        ? reconcileChainIds(prev.activeChainIds, chainIds, resolvedChainIds)
+        ? resolvedChainIds
         : [...(prev.activeChainIds || []), ...chainIds].filter((thing, i, arr) => arr.indexOf(thing) === i),
     }));
 

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -138,7 +138,7 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
       const { disable: walletConnectDisable } = walletConnectInstance;
 
       if (walletConnectDisable) {
-        void walletConnectDisable();
+        await walletConnectDisable();
       }
     }
 
@@ -280,6 +280,10 @@ const disconnectSession = (
   const previousActiveChainIds = [...(previousSession.activeChainIds || [])];
   const previousAccounts = previousSession.accounts ? { ...previousSession.accounts } : null;
   const walletType = useGrazInternalStore.getState().walletType;
+  const clearSessionState = () => {
+    const { wcSignClients } = useGrazSessionStore.getState();
+    useGrazSessionStore.setState({ ...grazSessionDefaultValues, wcSignClients });
+  };
 
   logger.info(LogCategory.WALLET, "Disconnecting", {
     function: LOG_FUNCTIONS.DISCONNECT,
@@ -316,7 +320,7 @@ const disconnectSession = (
     const isEmpty = Object.values(_accounts ? _accounts : {}).length === 0;
     if (isEmpty) {
       disable();
-      useGrazSessionStore.setState(grazSessionDefaultValues);
+      clearSessionState();
       useGrazInternalStore.setState({
         _reconnect: false,
         _reconnectConnector: null,
@@ -335,7 +339,7 @@ const disconnectSession = (
     }
   } else {
     disable();
-    useGrazSessionStore.setState(grazSessionDefaultValues);
+    clearSessionState();
     useGrazInternalStore.setState({
       _reconnect: false,
       _reconnectConnector: null,

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -11,6 +11,7 @@ import { WalletType } from "../types/wallet";
 import { LogCategory } from "../types/logger";
 import { getLogger } from "../utils/logger";
 import { checkWallet, getWallet, isPara, isWalletConnect } from "./wallet";
+import { resolveSession } from "./wallet/wallet-connect/approved-session";
 import { emitWalletEvent } from "./events";
 
 /**
@@ -34,6 +35,43 @@ export interface ConnectResult {
 const haveSameChainIds = (first: readonly string[], second: readonly string[]) => {
   return first.length === second.length && first.every((chainId) => second.includes(chainId));
 };
+
+const getWalletConnectResolvedChainIds = (
+  walletType: WalletType,
+  requestedChainIds: string[],
+  chains: ChainInfo[],
+) => {
+  const signClient = useGrazSessionStore.getState().wcSignClients.get(walletType);
+  if (!signClient) throw new Error("walletConnect.signClient is not defined");
+
+  const resolved = resolveSession(signClient.session.getAll().at(-1));
+  if (!resolved) throw new Error("No approved WalletConnect accounts");
+
+  const configuredChainIds = chains.map((chain) => chain.chainId);
+  const approvedChainIds = new Set(resolved.scope.chainIds);
+  const requested = requestedChainIds.filter(
+    (chainId) => approvedChainIds.has(chainId) && configuredChainIds.includes(chainId),
+  );
+  const additional = configuredChainIds.filter(
+    (chainId) => approvedChainIds.has(chainId) && !requested.includes(chainId),
+  );
+  const resolvedChainIds = [...requested, ...additional];
+  if (resolvedChainIds.length === 0) throw new Error("No approved WalletConnect accounts for configured chains");
+
+  return resolvedChainIds;
+};
+
+const reconcileChainIds = (current: string[] | null, requested: string[], resolved: string[]) =>
+  [...(current || []).filter((chainId) => !requested.includes(chainId)), ...resolved].filter(
+    (chainId, index, chainIds) => chainIds.indexOf(chainId) === index,
+  );
+
+const getConnectedChains = (chainIds: string[], chains: ChainInfo[]) =>
+  chainIds.map((chainId) => {
+    const chain = chains.find((candidate) => candidate.chainId === chainId);
+    if (!chain) throw new Error(`Chain ${chainId} is not provided in GrazProvider`);
+    return chain;
+  });
 
 const emitConnectedSessionChanges = ({
   previousAccounts,
@@ -145,6 +183,9 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
 
     logger.debug(LogCategory.WALLET, "Enabling chains", { function: LOG_FUNCTIONS.CONNECT, chainIds, chainCount: chainIds.length });
     await wallet.enable(chainIds);
+    const resolvedChainIds = isWalletConnect(currentWalletType)
+      ? getWalletConnectResolvedChainIds(currentWalletType, chainIds, chains || [])
+      : chainIds;
 
     logger.debug(LogCategory.WALLET, "Fetching accounts", { function: LOG_FUNCTIONS.CONNECT });
 
@@ -160,14 +201,14 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
     }
 
     useGrazInternalStore.setState((prev) => ({
-      recentChainIds: [...(prev.recentChainIds || []), ...chainIds].filter((thing, i, arr) => {
-        return arr.indexOf(thing) === i;
-      }),
+      recentChainIds: isWalletConnect(currentWalletType)
+        ? reconcileChainIds(prev.recentChainIds, chainIds, resolvedChainIds)
+        : [...(prev.recentChainIds || []), ...chainIds].filter((thing, i, arr) => arr.indexOf(thing) === i),
     }));
     useGrazSessionStore.setState((prev) => ({
-      activeChainIds: [...(prev.activeChainIds || []), ...chainIds].filter((thing, i, arr) => {
-        return arr.indexOf(thing) === i;
-      }),
+      activeChainIds: isWalletConnect(currentWalletType)
+        ? reconcileChainIds(prev.activeChainIds, chainIds, resolvedChainIds)
+        : [...(prev.activeChainIds || []), ...chainIds].filter((thing, i, arr) => arr.indexOf(thing) === i),
     }));
 
     useGrazInternalStore.setState({
@@ -180,8 +221,9 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
     });
     typeof window !== "undefined" && window.sessionStorage.setItem(RECONNECT_SESSION_KEY, "Active");
 
-    const connectedChains = chainIds.map((x) => chains!.find((y) => y.chainId === x)!);
-    const _resAcc = useGrazSessionStore.getState().accounts;
+    const connectedChains = getConnectedChains(resolvedChainIds, chains || []);
+    const resultAccounts = useGrazSessionStore.getState().accounts;
+    if (!resultAccounts) throw new Error("No accounts");
 
     if (wasConnected) {
       emitConnectedSessionChanges({
@@ -194,17 +236,20 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
     logger.info(LogCategory.WALLET, "Connection successful", {
       function: LOG_FUNCTIONS.CONNECT,
       walletType: currentWalletType,
-      chainCount: chainIds.length,
-      chainIds,
-      addresses: _resAcc ? Object.values(_resAcc).map((a) => a.bech32Address) : [],
+      chainCount: resolvedChainIds.length,
+      chainIds: resolvedChainIds,
+      addresses: Object.values(resultAccounts).map((account) => account.bech32Address),
     });
 
-    logger.debug(LogCategory.STORE, "Session store updated", { function: LOG_FUNCTIONS.CONNECT, accountCount: Object.keys(_resAcc || {}).length });
+    logger.debug(LogCategory.STORE, "Session store updated", {
+      function: LOG_FUNCTIONS.CONNECT,
+      accountCount: Object.keys(resultAccounts).length,
+    });
 
     logger.timeEnd("connect");
     logger.groupEnd();
 
-    return { accounts: _resAcc!, walletType: currentWalletType, chains: connectedChains };
+    return { accounts: resultAccounts, walletType: currentWalletType, chains: connectedChains };
   } catch (error) {
     logger.error(LogCategory.WALLET, "Connection failed", {
       function: LOG_FUNCTIONS.CONNECT,
@@ -368,13 +413,16 @@ export const reconnect = async (args?: ReconnectArgs) => {
         const wallet = getWallet(_reconnectConnector);
         await wallet.init?.();
         await wallet.enable(recentChains);
+        const { chains } = useGrazInternalStore.getState();
+        const resolvedChainIds = getWalletConnectResolvedChainIds(_reconnectConnector, recentChains, chains || []);
         useGrazInternalStore.setState({
           _reconnect,
           _reconnectConnector,
+          recentChainIds: resolvedChainIds,
           walletType: _reconnectConnector,
         });
         useGrazSessionStore.setState({
-          activeChainIds: [...recentChains],
+          activeChainIds: resolvedChainIds,
           status: "connected",
         });
         typeof window !== "undefined" && window.sessionStorage.setItem(RECONNECT_SESSION_KEY, "Active");
@@ -384,9 +432,7 @@ export const reconnect = async (args?: ReconnectArgs) => {
           walletType: _reconnectConnector,
         });
         const { accounts } = useGrazSessionStore.getState();
-        const { chains } = useGrazInternalStore.getState();
-        const connectedChains =
-          chains?.filter((chain) => recentChains.includes(chain.chainId)) || [];
+        const connectedChains = getConnectedChains(resolvedChainIds, chains || []);
         return {
           accounts: accounts || {},
           chains: connectedChains,

--- a/packages/graz/src/actions/account.ts
+++ b/packages/graz/src/actions/account.ts
@@ -10,7 +10,7 @@ import type { Key } from "../types/wallet";
 import { WalletType } from "../types/wallet";
 import { LogCategory } from "../types/logger";
 import { getLogger } from "../utils/logger";
-import { checkWallet, getWallet, isPara, isWalletConnect } from "./wallet";
+import { checkWallet, clearSession, getWallet, isPara, isWalletConnect } from "./wallet";
 import { resolveApprovedChainIds, resolveSession } from "./wallet/wallet-connect/approved-session";
 import { emitWalletEvent } from "./events";
 
@@ -128,15 +128,6 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
       timestamp: Date.now(),
     });
 
-    if (isWalletConnect(currentWalletType)) {
-      const walletConnectInstance = getWallet(WalletType.WALLETCONNECT);
-      const { disable: walletConnectDisable } = walletConnectInstance;
-
-      if (walletConnectDisable) {
-        await walletConnectDisable();
-      }
-    }
-
     const isWalletAvailable = checkWallet(currentWalletType);
     if (!isWalletAvailable) {
       logger.warn(LogCategory.WALLET, "Wallet not available", { function: LOG_FUNCTIONS.CONNECT, walletType: currentWalletType });
@@ -156,6 +147,16 @@ export const connect = async (args?: ConnectArgs): Promise<ConnectResult> => {
         throw new Error(`Chain ${chainId} is not provided in GrazProvider`);
       }
     });
+
+    if (isWalletConnect(currentWalletType)) {
+      const walletConnectInstance = getWallet(WalletType.WALLETCONNECT);
+      const { disable: walletConnectDisable } = walletConnectInstance;
+
+      if (walletConnectDisable) {
+        await walletConnectDisable();
+        clearSession();
+      }
+    }
 
     useGrazSessionStore.setState((x) => {
       const isReconnecting =

--- a/packages/graz/src/actions/wallet/__tests__/approved-session.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/approved-session.test.ts
@@ -1,7 +1,7 @@
 import type { SessionTypes } from "@walletconnect/types";
 import { describe, expect, it } from "vitest";
 
-import { resolveSession } from "../wallet-connect/approved-session";
+import { resolveApprovedChainIds, resolveSession } from "../wallet-connect/approved-session";
 
 const now = 1_700_000_000_000;
 
@@ -11,6 +11,27 @@ const makeSession = (namespaces: SessionTypes.Namespaces, expiry = Math.floor(no
     namespaces,
     topic: "topic-1",
   }) as SessionTypes.Struct;
+
+describe("resolveApprovedChainIds", () => {
+  const scope = {
+    accounts: [],
+    chainIds: ["cosmoshub-4", "osmosis-1", "neutron-1", "unconfigured-1"],
+  };
+
+  it("places requested approved chains first and configured extras after them", () => {
+    expect(
+      resolveApprovedChainIds(
+        scope,
+        ["osmosis-1", "rejected-1", "cosmoshub-4"],
+        ["neutron-1", "cosmoshub-4", "osmosis-1"],
+      ),
+    ).toEqual(["osmosis-1", "cosmoshub-4", "neutron-1"]);
+  });
+
+  it("returns an empty list without an approved configured chain", () => {
+    expect(resolveApprovedChainIds(scope, ["rejected-1"], ["rejected-1"])).toEqual([]);
+  });
+});
 
 describe("resolveSession", () => {
   it("resolves approved accounts from base and chain-scoped Cosmos namespaces", () => {

--- a/packages/graz/src/actions/wallet/__tests__/approved-session.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/approved-session.test.ts
@@ -1,0 +1,112 @@
+import type { SessionTypes } from "@walletconnect/types";
+import { describe, expect, it } from "vitest";
+
+import { resolveSession } from "../wallet-connect/approved-session";
+
+const now = 1_700_000_000_000;
+
+const makeSession = (namespaces: SessionTypes.Namespaces, expiry = Math.floor(now / 1000) + 60): SessionTypes.Struct =>
+  ({
+    expiry,
+    namespaces,
+    topic: "topic-1",
+  }) as SessionTypes.Struct;
+
+describe("resolveSession", () => {
+  it("resolves approved accounts from base and chain-scoped Cosmos namespaces", () => {
+    const session = makeSession({
+      cosmos: {
+        accounts: ["cosmos:cosmoshub-4:cosmos1hub", "not-an-account"],
+        events: [],
+        methods: [],
+      },
+      "cosmos:osmosis-1": {
+        accounts: ["cosmos:osmosis-1:osmo1account"],
+        events: [],
+        methods: [],
+      },
+      eip155: {
+        accounts: ["eip155:1:0xabc"],
+        events: [],
+        methods: [],
+      },
+    });
+
+    expect(resolveSession(session, { now })).toEqual({
+      session,
+      scope: {
+        accounts: [
+          { address: "cosmos1hub", chainId: "cosmoshub-4" },
+          { address: "osmo1account", chainId: "osmosis-1" },
+        ],
+        chainIds: ["cosmoshub-4", "osmosis-1"],
+      },
+    });
+  });
+
+  it("derives chains only from valid approved accounts", () => {
+    const session = makeSession({
+      cosmos: {
+        accounts: ["cosmos:cosmoshub-4:cosmos1hub", "cosmos::missing-chain", "cosmos:osmosis-1:", "eip155:1:0xabc"],
+        chains: ["cosmos:cosmoshub-4", "cosmos:osmosis-1"],
+        events: [],
+        methods: [],
+      },
+      "cosmos:neutron-1": {
+        accounts: ["cosmos:osmosis-1:wrong-scoped-chain"],
+        events: [],
+        methods: [],
+      },
+    });
+
+    expect(resolveSession(session, { now })?.scope).toEqual({
+      accounts: [{ address: "cosmos1hub", chainId: "cosmoshub-4" }],
+      chainIds: ["cosmoshub-4"],
+    });
+  });
+
+  it("returns undefined without a usable Cosmos account", () => {
+    expect(
+      resolveSession(
+        makeSession({
+          cosmos: {
+            accounts: [],
+            chains: ["cosmos:cosmoshub-4"],
+            events: [],
+            methods: [],
+          },
+        }),
+        { now },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("matches an existing session when any requested chain is approved", () => {
+    const session = makeSession({
+      cosmos: {
+        accounts: ["cosmos:cosmoshub-4:cosmos1hub", "cosmos:osmosis-1:osmo1account"],
+        events: [],
+        methods: [],
+      },
+    });
+
+    expect(resolveSession(session, { chainIds: ["juno-1", "osmosis-1"], now })?.scope.chainIds).toEqual([
+      "cosmoshub-4",
+      "osmosis-1",
+    ]);
+    expect(resolveSession(session, { chainIds: ["juno-1"], now })).toBeUndefined();
+  });
+
+  it("returns undefined for sessions within the expiry buffer", () => {
+    const namespaces = {
+      cosmos: {
+        accounts: ["cosmos:cosmoshub-4:cosmos1hub"],
+        events: [],
+        methods: [],
+      },
+    };
+
+    expect(resolveSession(makeSession(namespaces, Math.floor(now / 1000) + 1), { now })).toBeUndefined();
+    expect(resolveSession(makeSession(namespaces, Math.floor(now / 1000) + 2), { now })).toBeDefined();
+  });
+});

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { encodeSecp256k1Pubkey } from "@cosmjs/amino";
 import { fromBech32, toBase64, toBech32 } from "@cosmjs/encoding";
 
 const walletConnectModalMock = vi.hoisted(() => {
@@ -343,6 +344,49 @@ describe("WalletConnect first-session flow", () => {
       "cosmos_getAccounts",
       "cosmos_signDirect",
     ]);
+  });
+
+  it("restores a persisted approved public key before offline signing", async () => {
+    const chainId = "dimension_37-1";
+    const bech32Address = "xpla1lg22287cj523vgdah8z4287nuzct43tmdtj69w";
+    const encodedPubKey = "A3m6JXpt05gNs8LQJhrNd+8vSzBstrWRGfsRdzmrjPVi";
+    const approved = {
+      ...makeWalletConnectKey(chainId),
+      bech32Address,
+      pubKey: encodedPubKey,
+    };
+    const session = makeApprovedSession([approved], false);
+    const request = vi.fn().mockResolvedValue([
+      {
+        address: bech32Address,
+        algo: "secp256k1",
+        pubkey: encodedPubKey,
+      },
+    ]);
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({ approval: vi.fn().mockResolvedValue(session), uri: "wc:topic" }),
+      request,
+      session: { getAll: vi.fn(() => [session]) },
+    };
+    useGrazInternalStore.setState({ chains: [makeChainInfo(chainId)] });
+    useGrazSessionStore.setState({
+      accounts: null,
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const wallet = getWalletConnect();
+    await wallet.enable([chainId]);
+    const persistedAccounts = JSON.parse(
+      JSON.stringify(useGrazSessionStore.getState().accounts),
+    ) as NonNullable<ReturnType<typeof useGrazSessionStore.getState>["accounts"]>;
+    useGrazSessionStore.setState({ accounts: persistedAccounts });
+
+    const signer = await wallet.getOfflineSignerAuto(chainId);
+    const [account] = await signer.getAccounts();
+    if (!account) throw new Error("Expected an offline signer account");
+
+    expect(() => encodeSecp256k1Pubkey(account.pubkey)).not.toThrow();
+    expect(request).toHaveBeenCalledTimes(1);
   });
 
   it.each(["dimension_37-1", "cosmos:dimension_37-1"])(

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
@@ -32,6 +32,7 @@ import { useGrazInternalStore, useGrazSessionStore } from "../../../store";
 import { WalletType } from "../../../types/wallet";
 import { makeChainInfo } from "../../../__tests__/fixtures";
 import { getWalletConnect } from "../wallet-connect";
+import { connect } from "../../account";
 
 type WalletConnectStoredKey = {
   address: number[];
@@ -137,6 +138,60 @@ describe("WalletConnect first-session flow", () => {
         bech32Address: osmosis.bech32Address,
       },
     });
+  });
+
+  it("replaces disconnected chains with the newly approved scope on connect", async () => {
+    const chainA = makeWalletConnectKey("cosmoshub-4");
+    const chainB = makeWalletConnectKey("osmosis-1");
+    const chainC = makeWalletConnectKey("juno-1");
+    const chainD = makeWalletConnectKey("neutron-1");
+    const approved = { ...makeApprovedSession([chainA, chainD]), topic: "new-topic" };
+    let sessions = [makeApprovedSession([chainB, chainC])];
+    const signClient = {
+      core: { pairing: { pairings: { getAll: vi.fn(() => []) } } },
+      disconnect: vi.fn(async ({ topic }: { topic: string }) => {
+        sessions = sessions.filter((session) => session.topic !== topic);
+      }),
+      connect: vi.fn(async () => {
+        expect(sessions).toEqual([]);
+        return {
+          uri: "wc:new-topic",
+          approval: async () => {
+            sessions = [approved];
+            return approved;
+          },
+        };
+      }),
+      session: { getAll: vi.fn(() => sessions) },
+    };
+    useGrazInternalStore.setState({
+      chains: [chainA, chainB, chainC, chainD].map((key) => makeChainInfo(key.chainId)),
+      recentChainIds: [chainB.chainId, chainC.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+    useGrazSessionStore.setState({
+      activeChainIds: [chainB.chainId, chainC.chainId],
+      status: "connected",
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+    const wallet = getWalletConnect();
+    await wallet.enable([chainB.chainId, chainC.chainId]);
+    expect(Object.keys(useGrazSessionStore.getState().accounts!)).toEqual([chainB.chainId, chainC.chainId]);
+
+    const result = await connect({
+      chainId: [chainB.chainId, chainA.chainId],
+      walletType: WalletType.WALLETCONNECT,
+    });
+
+    expect(signClient.disconnect).toHaveBeenCalledWith(expect.objectContaining({ topic: "topic-1" }));
+    expect(signClient.connect).toHaveBeenCalledTimes(1);
+    expect(sessions).toEqual([approved]);
+    expect(Object.keys(result.accounts)).toEqual([chainA.chainId, chainD.chainId]);
+    expect(result.chains.map((chain) => chain.chainId)).toEqual([chainA.chainId, chainD.chainId]);
+    expect(useGrazSessionStore.getState().accounts).toEqual(result.accounts);
+    expect(useGrazSessionStore.getState().activeChainIds).toEqual([chainA.chainId, chainD.chainId]);
+    expect(useGrazInternalStore.getState().recentChainIds).toEqual([chainA.chainId, chainD.chainId]);
+    await expect(wallet.getKey(chainC.chainId)).rejects.toThrow("No wallet connect session");
   });
 
   it("passes custom mobile and desktop wallet lists to the WalletConnect modal", async () => {

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
@@ -275,6 +275,76 @@ describe("WalletConnect first-session flow", () => {
     });
   });
 
+  it("reuses a materialized approved account for offline signing", async () => {
+    const chainId = "dimension_37-1";
+    const bech32Address = "xpla1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5p95zd0";
+    const encodedPubKey = toBase64(new Uint8Array([4, 5, 6]));
+    const approved = {
+      ...makeWalletConnectKey(chainId),
+      bech32Address,
+      pubKey: encodedPubKey,
+    };
+    const session = makeApprovedSession([approved], false);
+    let sessions: ReturnType<typeof makeApprovedSession>[] = [];
+    const approval = vi.fn(async () => {
+      sessions = [session];
+      return session;
+    });
+    const request = vi.fn(async ({ request }: { chainId: string; request: { method: string } }) => {
+      if (request.method === "cosmos_getAccounts") {
+        return [{ address: bech32Address, algo: "secp256k1", pubkey: encodedPubKey }];
+      }
+      if (request.method === "cosmos_signDirect") {
+        return {
+          signature: {
+            pub_key: { type: "tendermint/PubKeySecp256k1", value: encodedPubKey },
+            signature: "signature",
+          },
+          signed: {
+            accountNumber: "7",
+            authInfoBytes: toBase64(new Uint8Array([1])),
+            bodyBytes: toBase64(new Uint8Array([2])),
+            chainId,
+          },
+        };
+      }
+      throw new Error(`Unexpected WalletConnect method: ${request.method}`);
+    });
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({ approval, uri: "wc:topic" }),
+      request,
+      session: { getAll: vi.fn(() => sessions) },
+    };
+    useGrazInternalStore.setState({ chains: [makeChainInfo(chainId)] });
+    useGrazSessionStore.setState({
+      accounts: null,
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const wallet = getWalletConnect();
+    await expect(wallet.enable([chainId])).resolves.toBeUndefined();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    const signer = await wallet.getOfflineSignerAuto(chainId);
+    await expect(signer.getAccounts()).resolves.toMatchObject([{ address: bech32Address }]);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    await expect(
+      "signDirect" in signer
+        ? signer.signDirect(bech32Address, {
+            accountNumber: 7n,
+            authInfoBytes: new Uint8Array([1]),
+            bodyBytes: new Uint8Array([2]),
+            chainId,
+          })
+        : Promise.reject(new Error("Expected direct signer")),
+    ).resolves.toBeDefined();
+    expect(request.mock.calls.map(([call]) => call.request.method)).toEqual([
+      "cosmos_getAccounts",
+      "cosmos_signDirect",
+    ]);
+  });
+
   it.each(["dimension_37-1", "cosmos:dimension_37-1"])(
     "normalizes standard Cosmos RPC account chain ID %s",
     async (responseChainId) => {

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toBase64 } from "@cosmjs/encoding";
 
 const walletConnectModalMock = vi.hoisted(() => {
   const instances: Array<{
@@ -228,6 +229,109 @@ describe("WalletConnect first-session flow", () => {
         bech32Address: `${chainId}1address`,
       },
     });
+  });
+
+  it("normalizes standard Cosmos RPC accounts without session properties", async () => {
+    const chainId = "dimension_37-1";
+    const address = Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+    const bech32Address = "xpla1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5p95zd0";
+    const pubKey = Uint8Array.from([4, 5, 6]);
+    const encodedPubKey = toBase64(pubKey);
+    const approved = {
+      ...makeWalletConnectKey(chainId),
+      address: [...address],
+      bech32Address,
+      pubKey: encodedPubKey,
+    };
+    const approval = vi.fn().mockResolvedValue(makeApprovedSession([approved], false));
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({ approval, uri: "wc:topic" }),
+      request: vi.fn().mockResolvedValue([
+        {
+          address: bech32Address,
+          algo: "secp256k1",
+          pubkey: encodedPubKey,
+        },
+      ]),
+      session: { getAll: vi.fn(() => []) },
+    };
+    useGrazInternalStore.setState({ chains: [makeChainInfo(chainId)] });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().enable([chainId])).resolves.toBeUndefined();
+
+    expect(Object.keys(useGrazSessionStore.getState().accounts ?? {})).toEqual([chainId]);
+    expect(useGrazSessionStore.getState().accounts?.[chainId]).toMatchObject({
+      address,
+      bech32Address,
+      pubKey,
+    });
+  });
+
+  it.each(["dimension_37-1", "cosmos:dimension_37-1"])(
+    "normalizes standard Cosmos RPC account chain ID %s",
+    async (responseChainId) => {
+      const chainId = "dimension_37-1";
+      const bech32Address = "xpla1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5p95zd0";
+      const encodedPubKey = toBase64(new Uint8Array([4, 5, 6]));
+      const approved = {
+        ...makeWalletConnectKey(chainId),
+        bech32Address,
+      };
+      const session = makeApprovedSession([approved], false);
+      const signClient = {
+        request: vi.fn().mockResolvedValue([
+          {
+            address: bech32Address,
+            algo: "secp256k1",
+            chainId: responseChainId,
+            pubkey: encodedPubKey,
+          },
+        ]),
+        session: { getAll: vi.fn(() => [session]) },
+      };
+      useGrazInternalStore.setState({ chains: [makeChainInfo(chainId)] });
+      useGrazSessionStore.setState({
+        accounts: null,
+        wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+      });
+
+      await expect(getWalletConnect().enable([chainId])).resolves.toBeUndefined();
+      expect(useGrazSessionStore.getState().accounts?.[chainId]?.bech32Address).toBe(bech32Address);
+    },
+  );
+
+  it("rejects a standard Cosmos RPC account outside the approved namespace", async () => {
+    const chainId = "dimension_37-1";
+    const approvedAddress = "xpla1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5p95zd0";
+    const responseAddress = "xpla1zsf3yygspu8q6rqtpgysspcxq5zqxqspn7xtws";
+    const approved = {
+      ...makeWalletConnectKey(chainId),
+      bech32Address: approvedAddress,
+    };
+    const session = makeApprovedSession([approved], false);
+    const signClient = {
+      request: vi.fn().mockResolvedValue([
+        {
+          address: responseAddress,
+          algo: "secp256k1",
+          pubkey: toBase64(new Uint8Array([4, 5, 6])),
+        },
+      ]),
+      session: { getAll: vi.fn(() => [session]) },
+    };
+    useGrazInternalStore.setState({ chains: [makeChainInfo(chainId)] });
+    useGrazSessionStore.setState({
+      accounts: null,
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().enable([chainId])).rejects.toThrow(
+      `No WalletConnect accounts for approved chains: ${chainId}`,
+    );
+    expect(useGrazSessionStore.getState().accounts).toBeNull();
   });
 
   it("materializes the approved configured subset, including configured chains outside the request", async () => {

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
@@ -28,6 +28,7 @@ vi.mock("@walletconnect/modal", () => ({
 
 import { useGrazInternalStore, useGrazSessionStore } from "../../../store";
 import { WalletType } from "../../../types/wallet";
+import { makeChainInfo } from "../../../__tests__/fixtures";
 import { getWalletConnect } from "../wallet-connect";
 
 type WalletConnectStoredKey = {
@@ -54,6 +55,25 @@ const makeWalletConnectKey = (chainId: string): WalletConnectStoredKey => ({
 
 const getWalletConnectChainId = (chainId: string) => chainId.split(":")[1] || chainId;
 
+const makeApprovedSession = (keys: WalletConnectStoredKey[], includeSessionProperties = true) => ({
+  expiry: Math.floor(Date.now() / 1000) + 60,
+  namespaces: {
+    cosmos: {
+      accounts: keys.map((key) => `cosmos:${key.chainId}:${key.bech32Address}`),
+      events: ["chainChanged", "accountsChanged"],
+      methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
+    },
+  },
+  ...(includeSessionProperties
+    ? {
+        sessionProperties: {
+          keys: JSON.stringify(keys),
+        },
+      }
+    : {}),
+  topic: "topic-1",
+});
+
 describe("WalletConnect first-session flow", () => {
   beforeEach(() => {
     walletConnectModalMock.instances.length = 0;
@@ -69,11 +89,7 @@ describe("WalletConnect first-session flow", () => {
   it("opens the modal, approves a new session, and stores approved accounts", async () => {
     const cosmoshub = makeWalletConnectKey("cosmoshub-4");
     const osmosis = makeWalletConnectKey("osmosis-1");
-    const approval = vi.fn().mockResolvedValue({
-      sessionProperties: {
-        keys: JSON.stringify([cosmoshub, osmosis]),
-      },
-    });
+    const approval = vi.fn().mockResolvedValue(makeApprovedSession([cosmoshub, osmosis]));
     const signClient = {
       connect: vi.fn().mockResolvedValue({
         approval,
@@ -86,13 +102,16 @@ describe("WalletConnect first-session flow", () => {
     useGrazSessionStore.setState({
       wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
     });
+    useGrazInternalStore.setState({
+      chains: [makeChainInfo(cosmoshub.chainId), makeChainInfo(osmosis.chainId)],
+    });
 
     const wallet = getWalletConnect();
 
     await expect(wallet.enable([cosmoshub.chainId, osmosis.chainId])).resolves.toBeUndefined();
 
     expect(signClient.connect).toHaveBeenCalledWith({
-      requiredNamespaces: {
+      optionalNamespaces: {
         cosmos: {
           chains: [`cosmos:${cosmoshub.chainId}`, `cosmos:${osmosis.chainId}`],
           events: ["chainChanged", "accountsChanged"],
@@ -115,11 +134,7 @@ describe("WalletConnect first-session flow", () => {
 
   it("passes custom mobile and desktop wallet lists to the WalletConnect modal", async () => {
     const chainId = "cosmoshub-4";
-    const approval = vi.fn().mockResolvedValue({
-      sessionProperties: {
-        keys: JSON.stringify([makeWalletConnectKey(chainId)]),
-      },
-    });
+    const approval = vi.fn().mockResolvedValue(makeApprovedSession([makeWalletConnectKey(chainId)]));
     const signClient = {
       connect: vi.fn().mockResolvedValue({
         approval,
@@ -150,6 +165,7 @@ describe("WalletConnect first-session flow", () => {
       },
     ];
     useGrazInternalStore.setState({
+      chains: [makeChainInfo(chainId)],
       walletConnect: {
         options: {
           projectId: "project-id",
@@ -177,9 +193,7 @@ describe("WalletConnect first-session flow", () => {
 
   it("requests accounts when an approved session does not include session properties", async () => {
     const chainId = "cosmoshub-4";
-    const approval = vi.fn().mockResolvedValue({
-      topic: "topic-1",
-    });
+    const approval = vi.fn().mockResolvedValue(makeApprovedSession([makeWalletConnectKey(chainId)], false));
     const signClient = {
       connect: vi.fn().mockResolvedValue({
         approval,
@@ -192,6 +206,9 @@ describe("WalletConnect first-session flow", () => {
     };
     useGrazSessionStore.setState({
       wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+    useGrazInternalStore.setState({
+      chains: [makeChainInfo(chainId)],
     });
 
     const wallet = getWalletConnect();
@@ -211,6 +228,165 @@ describe("WalletConnect first-session flow", () => {
         bech32Address: `${chainId}1address`,
       },
     });
+  });
+
+  it("materializes the approved configured subset, including configured chains outside the request", async () => {
+    const requested = makeWalletConnectKey("cosmoshub-4");
+    const omitted = makeWalletConnectKey("osmosis-1");
+    const additional = makeWalletConnectKey("neutron-1");
+    const approval = vi.fn().mockResolvedValue(makeApprovedSession([requested, additional]));
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({ approval, uri: "wc:topic" }),
+      session: { getAll: vi.fn(() => []) },
+    };
+    useGrazInternalStore.setState({
+      chains: [makeChainInfo(requested.chainId), makeChainInfo(omitted.chainId), makeChainInfo(additional.chainId)],
+    });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const wallet = getWalletConnect();
+
+    await expect(wallet.enable([requested.chainId, omitted.chainId])).resolves.toBeUndefined();
+    expect(useGrazSessionStore.getState().accounts).toMatchObject({
+      [requested.chainId]: { bech32Address: requested.bech32Address },
+      [additional.chainId]: { bech32Address: additional.bech32Address },
+    });
+    expect(useGrazSessionStore.getState().accounts?.[omitted.chainId]).toBeUndefined();
+  });
+
+  it("starts a fresh connection when the latest session has no requested account overlap", async () => {
+    const requested = makeWalletConnectKey("cosmoshub-4");
+    const existing = makeWalletConnectKey("osmosis-1");
+    const approval = vi.fn().mockResolvedValue({
+      ...makeApprovedSession([requested]),
+      topic: "fresh-topic",
+    });
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({ approval, uri: "wc:fresh-topic" }),
+      session: { getAll: vi.fn(() => [makeApprovedSession([existing])]) },
+    };
+    useGrazInternalStore.setState({
+      chains: [makeChainInfo(requested.chainId), makeChainInfo(existing.chainId)],
+    });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().enable([requested.chainId])).resolves.toBeUndefined();
+    expect(signClient.connect).toHaveBeenCalledTimes(1);
+    expect(useGrazSessionStore.getState().accounts?.[requested.chainId]).toMatchObject({
+      bech32Address: requested.bech32Address,
+    });
+  });
+
+  it("disconnects an expired latest session before starting a fresh connection", async () => {
+    const requested = makeWalletConnectKey("cosmoshub-4");
+    const expiredSession = {
+      ...makeApprovedSession([requested]),
+      expiry: Math.floor(Date.now() / 1000) - 1,
+      topic: "expired-topic",
+    };
+    const approval = vi.fn().mockResolvedValue({
+      ...makeApprovedSession([requested]),
+      topic: "fresh-topic",
+    });
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({ approval, uri: "wc:fresh-topic" }),
+      core: {
+        pairing: {
+          pairings: {
+            delete: vi.fn(),
+            getAll: vi.fn(() => []),
+          },
+        },
+      },
+      disconnect,
+      session: { getAll: vi.fn(() => [expiredSession]) },
+    };
+    useGrazInternalStore.setState({ chains: [makeChainInfo(requested.chainId)] });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().enable([requested.chainId])).resolves.toBeUndefined();
+    expect(disconnect).toHaveBeenCalledWith(expect.objectContaining({ topic: expiredSession.topic }));
+    expect(signClient.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnects a fresh session and preserves accounts when approved key materialization fails", async () => {
+    const requested = makeWalletConnectKey("cosmoshub-4");
+    const additional = makeWalletConnectKey("neutron-1");
+    const previous = makeWalletConnectKey("osmosis-1");
+    const approvedSession = makeApprovedSession([requested, additional]);
+    approvedSession.sessionProperties = {
+      keys: JSON.stringify([requested]),
+    };
+    const approval = vi.fn().mockResolvedValue(approvedSession);
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({ approval, uri: "wc:topic" }),
+      core: {
+        pairing: {
+          pairings: {
+            delete: vi.fn(),
+            getAll: vi.fn(() => []),
+          },
+        },
+      },
+      disconnect,
+      request: vi.fn().mockRejectedValue(new Error("account request failed")),
+      session: { getAll: vi.fn(() => []) },
+    };
+    useGrazInternalStore.setState({
+      chains: [makeChainInfo(requested.chainId), makeChainInfo(additional.chainId)],
+    });
+    useGrazSessionStore.setState({
+      accounts: { [previous.chainId]: previous as never },
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const wallet = getWalletConnect();
+
+    await expect(wallet.enable([requested.chainId])).rejects.toThrow("account request failed");
+    expect(disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        topic: approvedSession.topic,
+      }),
+    );
+    expect(useGrazSessionStore.getState().accounts).toEqual({ [previous.chainId]: previous });
+  });
+
+  it("rejects and disconnects a fresh session without an approved configured account", async () => {
+    const requested = makeWalletConnectKey("cosmoshub-4");
+    const unconfigured = makeWalletConnectKey("neutron-1");
+    const approvedSession = makeApprovedSession([unconfigured]);
+    const approval = vi.fn().mockResolvedValue(approvedSession);
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    const signClient = {
+      connect: vi.fn().mockResolvedValue({ approval, uri: "wc:topic" }),
+      core: {
+        pairing: {
+          pairings: {
+            delete: vi.fn(),
+            getAll: vi.fn(() => []),
+          },
+        },
+      },
+      disconnect,
+      session: { getAll: vi.fn(() => []) },
+    };
+    useGrazInternalStore.setState({ chains: [makeChainInfo(requested.chainId)] });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().enable([requested.chainId])).rejects.toThrow(
+      "No approved WalletConnect accounts for configured chains",
+    );
+    expect(disconnect).toHaveBeenCalledWith(expect.objectContaining({ topic: approvedSession.topic }));
   });
 
   it("rejects a new session without a WalletConnect URI", async () => {

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect-session-flow.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { toBase64 } from "@cosmjs/encoding";
+import { fromBech32, toBase64, toBech32 } from "@cosmjs/encoding";
 
 const walletConnectModalMock = vi.hoisted(() => {
   const instances: Array<{
@@ -43,10 +43,15 @@ type WalletConnectStoredKey = {
   pubKey: string;
 };
 
+const getWalletConnectAddressBytes = (chainId: string) =>
+  Uint8Array.from({ length: 20 }, (_, index) => chainId.charCodeAt(index % chainId.length));
+
+const getWalletConnectAddress = (chainId: string) => toBech32("cosmos", getWalletConnectAddressBytes(chainId));
+
 const makeWalletConnectKey = (chainId: string): WalletConnectStoredKey => ({
-  address: [1, 2, 3],
+  address: Array.from(getWalletConnectAddressBytes(chainId)),
   algo: "secp256k1",
-  bech32Address: `${chainId}1address`,
+  bech32Address: getWalletConnectAddress(chainId),
   chainId,
   isKeystone: false,
   isNanoLedger: false,
@@ -226,7 +231,7 @@ describe("WalletConnect first-session flow", () => {
     });
     expect(useGrazSessionStore.getState().accounts).toMatchObject({
       [chainId]: {
-        bech32Address: `${chainId}1address`,
+        bech32Address: getWalletConnectAddress(chainId),
       },
     });
   });
@@ -302,6 +307,62 @@ describe("WalletConnect first-session flow", () => {
       expect(useGrazSessionStore.getState().accounts?.[chainId]?.bech32Address).toBe(bech32Address);
     },
   );
+
+  it("rejects a standard Cosmos RPC account with a non-Cosmos CAIP-2 chain ID", async () => {
+    const chainId = "dimension_37-1";
+    const bech32Address = "xpla1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5p95zd0";
+    const approved = {
+      ...makeWalletConnectKey(chainId),
+      bech32Address,
+    };
+    const session = makeApprovedSession([approved], false);
+    const signClient = {
+      request: vi.fn().mockResolvedValue([
+        {
+          address: bech32Address,
+          algo: "secp256k1",
+          chainId: `eip155:${chainId}`,
+          pubkey: toBase64(new Uint8Array([4, 5, 6])),
+        },
+      ]),
+      session: { getAll: vi.fn(() => [session]) },
+    };
+    useGrazInternalStore.setState({ chains: [makeChainInfo(chainId)] });
+    useGrazSessionStore.setState({
+      accounts: null,
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().enable([chainId])).rejects.toThrow(
+      `No WalletConnect accounts for approved chains: ${chainId}`,
+    );
+    expect(useGrazSessionStore.getState().accounts).toBeNull();
+  });
+
+  it("derives a legacy account byte address from its approved bech32 address", async () => {
+    const chainId = "dimension_37-1";
+    const bech32Address = "xpla1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5p95zd0";
+    const approved = {
+      ...makeWalletConnectKey(chainId),
+      address: [99, 98, 97],
+      bech32Address,
+    };
+    const session = makeApprovedSession([approved]);
+    const signClient = {
+      request: vi.fn(),
+      session: { getAll: vi.fn(() => [session]) },
+    };
+    useGrazInternalStore.setState({ chains: [makeChainInfo(chainId)] });
+    useGrazSessionStore.setState({
+      accounts: null,
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().enable([chainId])).resolves.toBeUndefined();
+
+    expect(useGrazSessionStore.getState().accounts?.[chainId]?.address).toEqual(fromBech32(bech32Address).data);
+    expect(signClient.request).not.toHaveBeenCalled();
+  });
 
   it("rejects a standard Cosmos RPC account outside the approved namespace", async () => {
     const chainId = "dimension_37-1";

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -314,6 +314,35 @@ describe("WalletConnect adapter", () => {
     });
   });
 
+  it("keeps a reused session and previous accounts when approved key materialization fails", async () => {
+    const chainId = "cosmoshub-4";
+    const additionalChainId = "neutron-1";
+    const previousChainId = "osmosis-1";
+    const signClient = makeSignClient(chainId);
+    signClient.test.session.namespaces.cosmos.accounts.push(
+      `cosmos:${additionalChainId}:${additionalChainId}1address`,
+    );
+    useGrazInternalStore.setState({
+      chains: [makeChainInfo(chainId), makeChainInfo(additionalChainId)],
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    const previousAccount = makeWalletConnectKey(previousChainId) as unknown as Key;
+    useGrazSessionStore.setState({
+      accounts: { [previousChainId]: previousAccount },
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().enable([chainId])).rejects.toThrow(
+      `Expected cosmos_getAccounts for cosmos:${chainId}, received cosmos:${additionalChainId}`,
+    );
+    expect(signClient.disconnect).not.toHaveBeenCalled();
+    expect(useGrazSessionStore.getState().accounts).toEqual({ [previousChainId]: previousAccount });
+  });
+
   it("disconnects a multi-chain session only once", async () => {
     const chainId = "cosmoshub-4";
     const additionalChainId = "neutron-1";

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -127,6 +127,7 @@ const makeSignClient = (
 
 describe("WalletConnect adapter", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -377,6 +378,43 @@ describe("WalletConnect adapter", () => {
     expect(useGrazSessionStore.getState().accounts).toEqual({ [previousChainId]: previousAccount });
   });
 
+  it("does not update accounts when reused-session materialization resolves after timeout", async () => {
+    vi.useFakeTimers();
+    const chainId = "cosmoshub-4";
+    const previousChainId = "osmosis-1";
+    const signClient = makeSignClient(chainId, { includeSessionProperties: false });
+    let resolveAccounts!: (accounts: ReturnType<typeof makeWalletConnectKey>[]) => void;
+    const accounts = new Promise<ReturnType<typeof makeWalletConnectKey>[]>((resolve) => {
+      resolveAccounts = resolve;
+    });
+    signClient.request.mockImplementationOnce(() => accounts);
+    useGrazInternalStore.setState({
+      chains: [makeChainInfo(chainId)],
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    const previousAccount = makeWalletConnectKey(previousChainId) as unknown as Key;
+    useGrazSessionStore.setState({
+      accounts: { [previousChainId]: previousAccount },
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const enable = getWalletConnect().enable([chainId]);
+    const timeout = expect(enable).rejects.toThrow("Connection timeout");
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await timeout;
+    expect(useGrazSessionStore.getState().accounts).toEqual({ [previousChainId]: previousAccount });
+
+    resolveAccounts([makeWalletConnectKey(chainId)]);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(useGrazSessionStore.getState().accounts).toEqual({ [previousChainId]: previousAccount });
+  });
+
   it("disconnects a multi-chain session only once", async () => {
     const chainId = "cosmoshub-4";
     const additionalChainId = "neutron-1";
@@ -436,5 +474,48 @@ describe("WalletConnect adapter", () => {
 
     await expect(disconnects).resolves.toEqual([undefined, undefined]);
     expect(signClient.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    "Missing or invalid. Record was recently deleted - session: topic-1",
+    "Missing or invalid. session topic does not exist in keychain: topic-1",
+  ])("treats an already invalid WalletConnect session as disconnected: %s", async (message) => {
+    const chainId = "cosmoshub-4";
+    const signClient = makeSignClient(chainId);
+    signClient.disconnect.mockImplementationOnce(async () => {
+      signClient.session.getAll.mockReturnValue([]);
+      throw new Error(message);
+    });
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().disable?.()).resolves.toBeUndefined();
+    expect(useGrazSessionStore.getState().wcSignClients.get(WalletType.WALLETCONNECT)).toBe(signClient);
+  });
+
+  it("does not hide other WalletConnect disconnect failures", async () => {
+    const chainId = "cosmoshub-4";
+    const signClient = makeSignClient(chainId);
+    signClient.disconnect.mockRejectedValueOnce(new Error("Relay unavailable"));
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    await expect(getWalletConnect().disable?.()).rejects.toThrow("Relay unavailable");
   });
 });

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { toBech32 } from "@cosmjs/encoding";
+import { SignClient } from "@walletconnect/sign-client";
 
 import { makeChainInfo } from "../../../__tests__/fixtures";
 import { useGrazInternalStore, useGrazSessionStore } from "../../../store";
@@ -250,7 +251,10 @@ describe("WalletConnect adapter", () => {
         code: 7001,
       }),
     );
-    expect(useGrazSessionStore.getState().wcSignClients.has(WalletType.WALLETCONNECT)).toBe(false);
+    expect(useGrazSessionStore.getState().wcSignClients.get(WalletType.WALLETCONNECT)).toBe(signClient);
+    const initialize = vi.spyOn(SignClient, "init").mockRejectedValue(new Error("Unexpected SignClient re-init"));
+    await expect(wallet.init!()).resolves.toBe(signClient);
+    expect(initialize).not.toHaveBeenCalled();
     expect(useGrazInternalStore.getState()).toMatchObject({
       _reconnect: false,
       _reconnectConnector: null,
@@ -258,6 +262,30 @@ describe("WalletConnect adapter", () => {
     });
   });
 
+  it("coalesces concurrent SignClient initialization", async () => {
+    const chainId = "cosmoshub-4";
+    const signClient = makeSignClient(chainId);
+    let resolveInitialization!: (client: typeof signClient) => void;
+    const initialization = new Promise<typeof signClient>((resolve) => {
+      resolveInitialization = resolve;
+    });
+    const initialize = vi.spyOn(SignClient, "init").mockReturnValue(initialization as never);
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+
+    const first = getWalletConnect().init!();
+    const second = getWalletConnect().init!();
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    resolveInitialization(signClient);
+    await expect(Promise.all([first, second])).resolves.toEqual([signClient, signClient]);
+    expect(useGrazSessionStore.getState().wcSignClients.get(WalletType.WALLETCONNECT)).toBe(signClient);
+  });
   it("requests accounts for existing sessions without session properties", async () => {
     const chainId = "cosmoshub-4";
     const signClient = makeSignClient(chainId, { includeSessionProperties: false });

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { makeChainInfo } from "../../../__tests__/fixtures";
 import { useGrazInternalStore, useGrazSessionStore } from "../../../store";
 import { WalletType, type Key } from "../../../types/wallet";
 import { getWalletConnect } from "../wallet-connect";
@@ -28,6 +29,13 @@ const makeSignClient = (
   const listeners = new Map<string, Set<(args?: unknown) => void>>();
   const session = {
     expiry: Math.floor(Date.now() / 1000) + 60,
+    namespaces: {
+      cosmos: {
+        accounts: [`cosmos:${chainId}:${chainId}1address`],
+        events: ["chainChanged", "accountsChanged"],
+        methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
+      },
+    },
     requiredNamespaces: {
       cosmos: {
         chains: [`cosmos:${chainId}`],
@@ -105,6 +113,7 @@ const makeSignClient = (
     test: {
       deletePairing,
       listeners,
+      session,
     },
   };
 };
@@ -140,6 +149,7 @@ describe("WalletConnect adapter", () => {
     const wcSignClients = new Map();
     wcSignClients.set(WalletType.WALLETCONNECT, signClient);
     useGrazInternalStore.setState({
+      chains: [makeChainInfo(chainId)],
       walletConnect: {
         options: {
           projectId: "project-id",
@@ -302,5 +312,29 @@ describe("WalletConnect adapter", () => {
       },
       topic: "topic-1",
     });
+  });
+
+  it("disconnects a multi-chain session only once", async () => {
+    const chainId = "cosmoshub-4";
+    const additionalChainId = "neutron-1";
+    const signClient = makeSignClient(chainId);
+    signClient.test.session.namespaces.cosmos.accounts.push(
+      `cosmos:${additionalChainId}:${additionalChainId}1address`,
+    );
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const disable = getWalletConnect().disable as unknown as (chainIds: string[]) => Promise<void>;
+    await expect(disable([chainId, additionalChainId])).resolves.toBeUndefined();
+    expect(signClient.disconnect).toHaveBeenCalledTimes(1);
+    expect(signClient.disconnect).toHaveBeenCalledWith(expect.objectContaining({ topic: "topic-1" }));
   });
 });

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { toBech32 } from "@cosmjs/encoding";
 
 import { makeChainInfo } from "../../../__tests__/fixtures";
 import { useGrazInternalStore, useGrazSessionStore } from "../../../store";
@@ -8,10 +9,15 @@ import { getWCClot } from "../wallet-connect/clot";
 import { getWCCosmostation } from "../wallet-connect/cosmostation";
 import { getWCKeplr } from "../wallet-connect/keplr";
 
+const getWalletConnectAddressBytes = (chainId: string) =>
+  Uint8Array.from({ length: 20 }, (_, index) => chainId.charCodeAt(index % chainId.length));
+
+const getWalletConnectAddress = (chainId: string) => toBech32("cosmos", getWalletConnectAddressBytes(chainId));
+
 const makeWalletConnectKey = (chainId: string, overrides: Partial<Key> = {}) => ({
-  address: [1, 2, 3],
+  address: Array.from(getWalletConnectAddressBytes(chainId)),
   algo: "secp256k1",
-  bech32Address: `${chainId}1address`,
+  bech32Address: getWalletConnectAddress(chainId),
   chainId,
   isKeystone: false,
   isNanoLedger: false,
@@ -31,7 +37,7 @@ const makeSignClient = (
     expiry: Math.floor(Date.now() / 1000) + 60,
     namespaces: {
       cosmos: {
-        accounts: [`cosmos:${chainId}:${chainId}1address`],
+        accounts: [`cosmos:${chainId}:${getWalletConnectAddress(chainId)}`],
         events: ["chainChanged", "accountsChanged"],
         methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
       },
@@ -168,13 +174,13 @@ describe("WalletConnect adapter", () => {
 
     await expect(wallet.enable([chainId])).resolves.toBeUndefined();
     expect(useGrazSessionStore.getState().accounts?.[chainId]).toMatchObject({
-      bech32Address: `${chainId}1address`,
+      bech32Address: getWalletConnectAddress(chainId),
       name: "WalletConnect",
     });
 
     const key = await wallet.getKey(chainId);
     expect(key).toMatchObject({
-      bech32Address: `${chainId}1address`,
+      bech32Address: getWalletConnectAddress(chainId),
       isNanoLedger: false,
     });
     expect(Array.from(key.pubKey)).toEqual([4, 5, 6]);
@@ -185,13 +191,13 @@ describe("WalletConnect adapter", () => {
       wallet.getOfflineSigner(chainId).getAccounts(),
     ).resolves.toEqual([
       {
-        address: `${chainId}1address`,
+        address: getWalletConnectAddress(chainId),
         algo: "secp256k1",
         pubkey: Buffer.from(new Uint8Array([4, 5, 6])),
       },
     ]);
     await expect(
-      wallet.signDirect(chainId, `${chainId}1address`, {
+      wallet.signDirect(chainId, getWalletConnectAddress(chainId), {
         accountNumber: 7n,
         authInfoBytes: new Uint8Array([1]),
         bodyBytes: new Uint8Array([2]),
@@ -221,7 +227,7 @@ describe("WalletConnect adapter", () => {
       params: {
         chainId: `cosmos:${chainId}`,
         event: {
-          data: [`${chainId}1address`],
+          data: [getWalletConnectAddress(chainId)],
           name: "accountsChanged",
         },
       },
@@ -271,7 +277,7 @@ describe("WalletConnect adapter", () => {
     const wallet = getWalletConnect();
 
     await expect(wallet.getKey(chainId)).resolves.toMatchObject({
-      bech32Address: `${chainId}1address`,
+      bech32Address: getWalletConnectAddress(chainId),
     });
     expect(signClient.request).toHaveBeenCalledWith({
       chainId: `cosmos:${chainId}`,
@@ -302,7 +308,7 @@ describe("WalletConnect adapter", () => {
     const wallet = getWalletConnect();
 
     await expect(wallet.getKey(chainId)).resolves.toMatchObject({
-      bech32Address: `${chainId}1address`,
+      bech32Address: getWalletConnectAddress(chainId),
     });
     expect(signClient.request).toHaveBeenCalledWith({
       chainId: `cosmos:${chainId}`,
@@ -320,7 +326,7 @@ describe("WalletConnect adapter", () => {
     const previousChainId = "osmosis-1";
     const signClient = makeSignClient(chainId);
     signClient.test.session.namespaces.cosmos.accounts.push(
-      `cosmos:${additionalChainId}:${additionalChainId}1address`,
+      `cosmos:${additionalChainId}:${getWalletConnectAddress(additionalChainId)}`,
     );
     useGrazInternalStore.setState({
       chains: [makeChainInfo(chainId), makeChainInfo(additionalChainId)],
@@ -348,7 +354,7 @@ describe("WalletConnect adapter", () => {
     const additionalChainId = "neutron-1";
     const signClient = makeSignClient(chainId);
     signClient.test.session.namespaces.cosmos.accounts.push(
-      `cosmos:${additionalChainId}:${additionalChainId}1address`,
+      `cosmos:${additionalChainId}:${getWalletConnectAddress(additionalChainId)}`,
     );
     useGrazInternalStore.setState({
       walletConnect: {

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -372,4 +372,41 @@ describe("WalletConnect adapter", () => {
     expect(signClient.disconnect).toHaveBeenCalledTimes(1);
     expect(signClient.disconnect).toHaveBeenCalledWith(expect.objectContaining({ topic: "topic-1" }));
   });
+
+  it("coalesces concurrent disconnects for the same session topic", async () => {
+    const chainId = "cosmoshub-4";
+    const signClient = makeSignClient(chainId);
+    let resolveDisconnect!: () => void;
+    const disconnecting = new Promise<void>((resolve) => {
+      resolveDisconnect = resolve;
+    });
+    const disconnect = signClient.disconnect.getMockImplementation();
+    let disconnected = false;
+    signClient.disconnect.mockImplementation(async (params) => {
+      await disconnecting;
+      if (disconnected) {
+        throw new Error("Missing or invalid. Record was recently deleted - session: topic-1");
+      }
+      disconnected = true;
+      await disconnect?.(params);
+    });
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const firstDisable = getWalletConnect().disable as () => Promise<void>;
+    const secondDisable = getWalletConnect().disable as () => Promise<void>;
+    const disconnects = Promise.all([firstDisable(), secondDisable()]);
+    resolveDisconnect();
+
+    await expect(disconnects).resolves.toEqual([undefined, undefined]);
+    expect(signClient.disconnect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
+++ b/packages/graz/src/actions/wallet/__tests__/wallet-connect.test.ts
@@ -287,6 +287,79 @@ describe("WalletConnect adapter", () => {
     await expect(Promise.all([first, second])).resolves.toEqual([signClient, signClient]);
     expect(useGrazSessionStore.getState().wcSignClients.get(WalletType.WALLETCONNECT)).toBe(signClient);
   });
+  it("uses the latest approved optional-only session for signing", async () => {
+    const chainId = "cosmoshub-4";
+    const previousAddressBytes = Uint8Array.from({ length: 20 }, () => 1);
+    const previousAddress = toBech32("cosmos", previousAddressBytes);
+    const previousKey = makeWalletConnectKey(chainId, {
+      address: previousAddressBytes,
+      bech32Address: previousAddress,
+    });
+    const latestKey = makeWalletConnectKey(chainId);
+    const signClient = makeSignClient(chainId);
+    const previousSession = {
+      ...signClient.test.session,
+      namespaces: {
+        cosmos: {
+          ...signClient.test.session.namespaces.cosmos,
+          accounts: [`cosmos:${chainId}:${previousAddress}`],
+        },
+      },
+      sessionProperties: { keys: JSON.stringify([previousKey]) },
+      topic: "previous-topic",
+    };
+    const latestSession = {
+      ...signClient.test.session,
+      namespaces: {
+        cosmos: {
+          ...signClient.test.session.namespaces.cosmos,
+          accounts: [`cosmos:${chainId}:${latestKey.bech32Address}`],
+        },
+      },
+      requiredNamespaces: {},
+      sessionProperties: { keys: JSON.stringify([latestKey]) },
+      topic: "latest-topic",
+    };
+    signClient.session.getAll.mockReturnValue([previousSession, latestSession] as never);
+    useGrazInternalStore.setState({
+      chains: [makeChainInfo(chainId)],
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      accounts: { [chainId]: latestKey as unknown as Key },
+      activeChainIds: [chainId],
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const signer = await getWalletConnect().getOfflineSignerAuto(chainId);
+    await expect(signer.getAccounts()).resolves.toMatchObject([
+      {
+        address: latestKey.bech32Address,
+      },
+    ]);
+
+    await expect(
+      "signDirect" in signer
+        ? signer.signDirect(latestKey.bech32Address, {
+            accountNumber: 7n,
+            authInfoBytes: new Uint8Array([1]),
+            bodyBytes: new Uint8Array([2]),
+            chainId,
+          })
+        : Promise.reject(new Error("Expected direct signer")),
+    ).resolves.toBeDefined();
+    expect(signClient.request).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({ method: "cosmos_signDirect" }),
+        topic: "latest-topic",
+      }),
+    );
+  });
+
   it("requests accounts for existing sessions without session properties", async () => {
     const chainId = "cosmoshub-4";
     const signClient = makeSignClient(chainId, { includeSessionProperties: false });
@@ -308,6 +381,70 @@ describe("WalletConnect adapter", () => {
     await expect(wallet.getKey(chainId)).resolves.toMatchObject({
       bech32Address: getWalletConnectAddress(chainId),
     });
+    expect(signClient.request).toHaveBeenCalledWith({
+      chainId: `cosmos:${chainId}`,
+      request: {
+        method: "cosmos_getAccounts",
+        params: {},
+      },
+      topic: "topic-1",
+    });
+  });
+
+  it("does not reuse a stored account outside the latest approved identity", async () => {
+    const chainId = "cosmoshub-4";
+    const signClient = makeSignClient(chainId, { includeSessionProperties: false });
+    const staleChainId = "osmosis-1";
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      accounts: {
+        [chainId]: makeWalletConnectKey(chainId, {
+          address: getWalletConnectAddressBytes(staleChainId),
+          bech32Address: getWalletConnectAddress(staleChainId),
+        }) as unknown as Key,
+      },
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const signer = await getWalletConnect().getOfflineSignerAuto(chainId);
+
+    expect("signDirect" in signer).toBe(true);
+    expect(signClient.request).toHaveBeenCalledTimes(1);
+    expect(signClient.request).toHaveBeenCalledWith({
+      chainId: `cosmos:${chainId}`,
+      request: {
+        method: "cosmos_getAccounts",
+        params: {},
+      },
+      topic: "topic-1",
+    });
+  });
+
+  it("requests accounts for an offline signer when no stored account exists", async () => {
+    const chainId = "cosmoshub-4";
+    const signClient = makeSignClient(chainId, { includeSessionProperties: false });
+    useGrazInternalStore.setState({
+      walletConnect: {
+        options: {
+          projectId: "project-id",
+        },
+      },
+    });
+    useGrazSessionStore.setState({
+      accounts: null,
+      wcSignClients: new Map([[WalletType.WALLETCONNECT, signClient as never]]),
+    });
+
+    const signer = await getWalletConnect().getOfflineSignerAuto(chainId);
+
+    expect("signDirect" in signer).toBe(true);
+    expect(signClient.request).toHaveBeenCalledTimes(1);
     expect(signClient.request).toHaveBeenCalledWith({
       chainId: `cosmos:${chainId}`,
       request: {

--- a/packages/graz/src/actions/wallet/index.ts
+++ b/packages/graz/src/actions/wallet/index.ts
@@ -41,7 +41,8 @@ export const checkWallet = (type: WalletType = useGrazInternalStore.getState().w
 
 export const clearSession = () => {
   window.sessionStorage.removeItem(RECONNECT_SESSION_KEY);
-  useGrazSessionStore.setState(grazSessionDefaultValues);
+  const { wcSignClients } = useGrazSessionStore.getState();
+  useGrazSessionStore.setState({ ...grazSessionDefaultValues, wcSignClients });
 };
 
 /**

--- a/packages/graz/src/actions/wallet/wallet-connect/approved-session.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/approved-session.ts
@@ -16,6 +16,22 @@ export type ResolvedSession = {
   scope: SessionScope;
 };
 
+export const resolveApprovedChainIds = (
+  scope: SessionScope,
+  requestedChainIds: readonly string[],
+  configuredChainIds: readonly string[],
+): string[] => {
+  const approved = new Set(scope.chainIds);
+  const requested = requestedChainIds.filter(
+    (chainId) => approved.has(chainId) && configuredChainIds.includes(chainId),
+  );
+  const additional = configuredChainIds.filter(
+    (chainId) => approved.has(chainId) && !requested.includes(chainId),
+  );
+
+  return [...requested, ...additional];
+};
+
 export const resolveSession = (
   session: SessionTypes.Struct | undefined,
   options: { chainIds?: readonly string[]; now?: number } = {},

--- a/packages/graz/src/actions/wallet/wallet-connect/approved-session.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/approved-session.ts
@@ -22,8 +22,7 @@ export const resolveSession = (
 ): ResolvedSession | undefined => {
   if (!session || session.expiry * 1000 <= (options.now ?? Date.now()) + 1000) return;
 
-  const accounts: ApprovedAccount[] = [];
-  const seenAccounts = new Set<string>();
+  const accounts = new Map<string, ApprovedAccount>();
 
   for (const [namespaceKey, namespace] of Object.entries(session.namespaces ?? {})) {
     if (parseNamespaceKey(namespaceKey) !== "cosmos" || !Array.isArray(namespace.accounts)) continue;
@@ -38,21 +37,20 @@ export const resolveSession = (
       if (scopedChainId && scopedChainId !== chainId) continue;
 
       const accountKey = `${chainId}:${address}`;
-      if (seenAccounts.has(accountKey)) continue;
-      seenAccounts.add(accountKey);
-      accounts.push({ address, chainId });
+      accounts.set(accountKey, { address, chainId });
     }
   }
 
-  if (accounts.length === 0) return;
+  const approvedAccounts = [...accounts.values()];
+  if (approvedAccounts.length === 0) return;
 
-  const chainIds = [...new Set(accounts.map((account) => account.chainId))];
+  const chainIds = [...new Set(approvedAccounts.map((account) => account.chainId))];
   if (options.chainIds?.length && !options.chainIds.some((chainId) => chainIds.includes(chainId))) return;
 
   return {
     session,
     scope: {
-      accounts,
+      accounts: approvedAccounts,
       chainIds,
     },
   };

--- a/packages/graz/src/actions/wallet/wallet-connect/approved-session.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/approved-session.ts
@@ -32,15 +32,10 @@ export const resolveApprovedChainIds = (
   return [...requested, ...additional];
 };
 
-export const resolveSession = (
-  session: SessionTypes.Struct | undefined,
-  options: { chainIds?: readonly string[]; now?: number } = {},
-): ResolvedSession | undefined => {
-  if (!session || session.expiry * 1000 <= (options.now ?? Date.now()) + 1000) return;
-
+export const resolveSessionScope = (namespaces: SessionTypes.Namespaces | undefined): SessionScope | undefined => {
   const accounts = new Map<string, ApprovedAccount>();
 
-  for (const [namespaceKey, namespace] of Object.entries(session.namespaces ?? {})) {
+  for (const [namespaceKey, namespace] of Object.entries(namespaces ?? {})) {
     if (parseNamespaceKey(namespaceKey) !== "cosmos" || !Array.isArray(namespace.accounts)) continue;
 
     const scopedChainId = namespaceKey.includes(":") ? parseChainId(namespaceKey).reference : undefined;
@@ -60,14 +55,24 @@ export const resolveSession = (
   const approvedAccounts = [...accounts.values()];
   if (approvedAccounts.length === 0) return;
 
-  const chainIds = [...new Set(approvedAccounts.map((account) => account.chainId))];
-  if (options.chainIds?.length && !options.chainIds.some((chainId) => chainIds.includes(chainId))) return;
+  return {
+    accounts: approvedAccounts,
+    chainIds: [...new Set(approvedAccounts.map((account) => account.chainId))],
+  };
+};
+
+export const resolveSession = (
+  session: SessionTypes.Struct | undefined,
+  options: { chainIds?: readonly string[]; now?: number } = {},
+): ResolvedSession | undefined => {
+  if (!session || session.expiry * 1000 <= (options.now ?? Date.now()) + 1000) return;
+
+  const scope = resolveSessionScope(session.namespaces);
+  if (!scope) return;
+  if (options.chainIds?.length && !options.chainIds.some((chainId) => scope.chainIds.includes(chainId))) return;
 
   return {
     session,
-    scope: {
-      accounts: approvedAccounts,
-      chainIds,
-    },
+    scope,
   };
 };

--- a/packages/graz/src/actions/wallet/wallet-connect/approved-session.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/approved-session.ts
@@ -1,0 +1,59 @@
+import type { SessionTypes } from "@walletconnect/types";
+import { parseAccountId, parseChainId, parseNamespaceKey } from "@walletconnect/utils";
+
+export type ApprovedAccount = {
+  address: string;
+  chainId: string;
+};
+
+export type SessionScope = {
+  accounts: ApprovedAccount[];
+  chainIds: string[];
+};
+
+export type ResolvedSession = {
+  session: SessionTypes.Struct;
+  scope: SessionScope;
+};
+
+export const resolveSession = (
+  session: SessionTypes.Struct | undefined,
+  options: { chainIds?: readonly string[]; now?: number } = {},
+): ResolvedSession | undefined => {
+  if (!session || session.expiry * 1000 <= (options.now ?? Date.now()) + 1000) return;
+
+  const accounts: ApprovedAccount[] = [];
+  const seenAccounts = new Set<string>();
+
+  for (const [namespaceKey, namespace] of Object.entries(session.namespaces ?? {})) {
+    if (parseNamespaceKey(namespaceKey) !== "cosmos" || !Array.isArray(namespace.accounts)) continue;
+
+    const scopedChainId = namespaceKey.includes(":") ? parseChainId(namespaceKey).reference : undefined;
+
+    for (const accountId of namespace.accounts) {
+      if (typeof accountId !== "string" || accountId.split(":").length !== 3) continue;
+
+      const { namespace: accountNamespace, reference: chainId, address } = parseAccountId(accountId);
+      if (accountNamespace !== "cosmos" || !chainId || !address) continue;
+      if (scopedChainId && scopedChainId !== chainId) continue;
+
+      const accountKey = `${chainId}:${address}`;
+      if (seenAccounts.has(accountKey)) continue;
+      seenAccounts.add(accountKey);
+      accounts.push({ address, chainId });
+    }
+  }
+
+  if (accounts.length === 0) return;
+
+  const chainIds = [...new Set(accounts.map((account) => account.chainId))];
+  if (options.chainIds?.length && !options.chainIds.some((chainId) => chainIds.includes(chainId))) return;
+
+  return {
+    session,
+    scope: {
+      accounts,
+      chainIds,
+    },
+  };
+};

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -311,14 +311,6 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     return accounts;
   };
 
-  const commitAccounts = (accounts: Record<string, Key>, requestedChainIds: string[]) => {
-    useGrazSessionStore.setState((previous) => {
-      const nextAccounts = { ...(previous.accounts ?? {}) };
-      requestedChainIds.forEach((chainId) => delete nextAccounts[chainId]);
-      return { accounts: { ...nextAccounts, ...accounts } };
-    });
-  };
-
   const init = async () => {
     const { walletConnect } = useGrazInternalStore.getState();
     if (!walletConnect?.options) throw new Error("walletConnect.options is not defined");
@@ -447,7 +439,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
         const approved = resolveSession(approvedSession);
         if (!approved) throw new Error("No approved WalletConnect accounts");
         const accounts = await materializeAccounts(signClient, approved, chainId);
-        commitAccounts(accounts, chainId);
+        useGrazSessionStore.setState({ accounts });
       } catch (error) {
         walletConnectModal.closeModal();
         if (approvedSession?.topic) await wcDisconnect(approvedSession.topic).catch(() => undefined);
@@ -464,7 +456,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       15000,
       new Error("Connection timeout"),
     );
-    commitAccounts(accounts, chainId);
+    useGrazSessionStore.setState({ accounts });
   };
 
   const resolveStoredApprovedKey = (chainId: string): Key | undefined => {

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -467,8 +467,26 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     commitAccounts(accounts, chainId);
   };
 
+  const resolveStoredApprovedKey = (chainId: string): Key | undefined => {
+    const { accounts, wcSignClients } = useGrazSessionStore.getState();
+    const storedKey = accounts?.[chainId];
+    const wcSignClient = wcSignClients.get(walletType);
+    if (!storedKey || !wcSignClient) return;
+
+    try {
+      const allSession = wcSignClient.session.getAll();
+      const resolvedSession = resolveSession(allSession[allSession.length - 1], { chainIds: [chainId] });
+      const isApproved = resolvedSession?.scope.accounts.some(
+        (account) => account.chainId === chainId && account.address === storedKey.bech32Address,
+      );
+      return isApproved ? storedKey : undefined;
+    } catch (error) {
+      if (!isMissingWalletConnectRecordError(error)) throw error;
+    }
+  };
+
   const getAccount = async (chainId: string): Promise<AccountData> => {
-    const key = await getKey(chainId);
+    const key = resolveStoredApprovedKey(chainId) ?? (await getKey(chainId));
 
     return {
       address: key.bech32Address,
@@ -600,7 +618,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   };
 
   const getOfflineSignerAuto = async (chainId: string) => {
-    const key = await getKey(chainId);
+    const key = resolveStoredApprovedKey(chainId) ?? (await getKey(chainId));
     if (key.isNanoLedger) return getOfflineSignerOnlyAmino(chainId);
     return getOfflineSignerDirect(chainId);
   };

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -11,7 +11,7 @@ import type { Key } from "../../../types/wallet";
 import { type SignAminoParams, type SignDirectParams, type Wallet, WalletType } from "../../../types/wallet";
 import { isAndroid, isIos, isMobile } from "../../../utils/os";
 import { promiseWithTimeout } from "../../../utils/timeout";
-import { type ResolvedSession, resolveSession } from "./approved-session";
+import { type ResolvedSession, resolveApprovedChainIds, resolveSession } from "./approved-session";
 import type { GetWalletConnectParams, WalletConnectSignDirectResponse } from "./types";
 
 type WalletConnectStoredKey = Omit<Key, "pubKey"> & { chainId?: string; pubKey: Key["pubKey"] | string };
@@ -198,24 +198,13 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     return keys;
   };
 
-  const getApprovedConfiguredChainIds = (resolvedSession: ResolvedSession, requestedChainIds: string[]) => {
-    const configuredChainIds = useGrazInternalStore.getState().chains?.map((chain) => chain.chainId) ?? requestedChainIds;
-    const approvedChainIds = new Set(resolvedSession.scope.chainIds);
-    const requested = requestedChainIds.filter(
-      (chainId) => approvedChainIds.has(chainId) && configuredChainIds.includes(chainId),
-    );
-    const additional = configuredChainIds.filter(
-      (chainId) => approvedChainIds.has(chainId) && !requested.includes(chainId),
-    );
-    return [...requested, ...additional];
-  };
-
   const materializeAccounts = async (
     signClient: ISignClient,
     resolvedSession: ResolvedSession,
     requestedChainIds: string[],
   ) => {
-    const chainIds = getApprovedConfiguredChainIds(resolvedSession, requestedChainIds);
+    const configuredChainIds = useGrazInternalStore.getState().chains?.map((chain) => chain.chainId) ?? requestedChainIds;
+    const chainIds = resolveApprovedChainIds(resolvedSession.scope, requestedChainIds, configuredChainIds);
     if (chainIds.length === 0) throw new Error("No approved WalletConnect accounts for configured chains");
 
     const keys = await getSessionKeys(signClient, resolvedSession, chainIds);

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -29,6 +29,8 @@ type WalletConnectAccount = {
 
 type WalletConnectStoredKey = Key & { chainId?: string };
 
+const disconnectingSessions = new WeakMap<ISignClient, Map<string, Promise<void>>>();
+
 export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   if (!useGrazInternalStore.getState().walletConnect?.options?.projectId?.trim()) {
     throw new Error("walletConnect.options.projectId is not defined");
@@ -68,17 +70,31 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     });
   };
 
-  const wcDisconnect = async (topic?: string) => {
+  const wcDisconnect = (topic?: string): Promise<void> => {
     const { wcSignClients } = useGrazSessionStore.getState();
     const wcSignClient = wcSignClients.get(walletType);
     if (!wcSignClient) throw new Error("walletConnect.signClient is not defined");
     if (!topic) throw new Error("No wallet connect session");
 
-    await wcSignClient.disconnect({
-      topic,
-      reason: getSdkError("USER_DISCONNECTED"),
+    const clientDisconnects = disconnectingSessions.get(wcSignClient) ?? new Map<string, Promise<void>>();
+    disconnectingSessions.set(wcSignClient, clientDisconnects);
+    const pendingDisconnect = clientDisconnects.get(topic);
+    if (pendingDisconnect) return pendingDisconnect;
+
+    const disconnect = (async () => {
+      await wcSignClient.disconnect({
+        topic,
+        reason: getSdkError("USER_DISCONNECTED"),
+      });
+      await deleteInactivePairings(wcSignClient);
+    })();
+    const trackedDisconnect = disconnect.finally(() => {
+      if (clientDisconnects.get(topic) !== trackedDisconnect) return;
+      clientDisconnects.delete(topic);
+      if (clientDisconnects.size === 0) disconnectingSessions.delete(wcSignClient);
     });
-    await deleteInactivePairings(wcSignClient);
+    clientDisconnects.set(topic, trackedDisconnect);
+    return trackedDisconnect;
   };
 
   const getSession = (chainIds: string[]) => {
@@ -584,7 +600,10 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       }
 
       // if no more sessions, remove signClient
-      if (signClient?.session.getAll().length === 0) {
+      if (
+        signClient?.session.getAll().length === 0 &&
+        useGrazSessionStore.getState().wcSignClients.get(walletType) === signClient
+      ) {
         _disconnect();
       }
     },

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -30,6 +30,7 @@ type WalletConnectAccount = {
 type WalletConnectStoredKey = Key & { chainId?: string };
 
 const disconnectingSessions = new WeakMap<ISignClient, Map<string, Promise<void>>>();
+const initializingSignClients = new Map<WalletType, Promise<ISignClient>>();
 
 export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   if (!useGrazInternalStore.getState().walletConnect?.options?.projectId?.trim()) {
@@ -54,15 +55,6 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   };
 
   const _disconnect = () => {
-    const { wcSignClients } = useGrazSessionStore.getState();
-    const wcSignClient = wcSignClients.get(walletType);
-    if (!wcSignClient) throw new Error("walletConnect.signClient is not defined");
-
-    wcSignClients.delete(walletType);
-    useGrazSessionStore.setState({
-      wcSignClients,
-    });
-
     useGrazInternalStore.setState({
       _reconnect: false,
       _reconnectConnector: null,
@@ -313,15 +305,33 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   const init = async () => {
     const { walletConnect } = useGrazInternalStore.getState();
     if (!walletConnect?.options) throw new Error("walletConnect.options is not defined");
+    const options = walletConnect.options;
     const { wcSignClients } = useGrazSessionStore.getState();
     const wcSignClient = wcSignClients.get(walletType);
     if (wcSignClient) {
       return wcSignClient;
     }
-    const signClient = await SignClient.init(walletConnect.options);
-    wcSignClients.set(walletType, signClient);
-    useGrazSessionStore.setState({ wcSignClients });
-    return signClient;
+
+    const pendingInitialization = initializingSignClients.get(walletType);
+    if (pendingInitialization) return pendingInitialization;
+
+    const initialization = (async () => {
+      const signClient = await SignClient.init(options);
+      const currentClients = new Map(useGrazSessionStore.getState().wcSignClients);
+      const currentClient = currentClients.get(walletType);
+      if (currentClient) return currentClient;
+
+      currentClients.set(walletType, signClient);
+      useGrazSessionStore.setState({ wcSignClients: currentClients });
+      return signClient;
+    })();
+    initializingSignClients.set(walletType, initialization);
+
+    try {
+      return await initialization;
+    } finally {
+      if (initializingSignClients.get(walletType) === initialization) initializingSignClients.delete(walletType);
+    }
   };
 
   const subscription: (reconnect: () => void) => () => void = (reconnect) => {
@@ -599,7 +609,8 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
         await Promise.all([...topics].map(wcDisconnect));
       }
 
-      // if no more sessions, remove signClient
+      // Keep the SignClient alive after its last session so reconnects do not
+      // create another Engine over the same WalletConnect Core namespace.
       if (
         signClient?.session.getAll().length === 0 &&
         useGrazSessionStore.getState().wcSignClients.get(walletType) === signClient

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -1,4 +1,5 @@
 import type { AminoSignResponse } from "@cosmjs/amino";
+import { fromBase64, fromBech32 } from "@cosmjs/encoding";
 import type { AccountData, Algo, DirectSignResponse } from "@cosmjs/proto-signing";
 import type { Keplr } from "@keplr-wallet/types";
 import { WalletConnectModal } from "@walletconnect/modal";
@@ -14,7 +15,19 @@ import { promiseWithTimeout } from "../../../utils/timeout";
 import { type ResolvedSession, resolveApprovedChainIds, resolveSession } from "./approved-session";
 import type { GetWalletConnectParams, WalletConnectSignDirectResponse } from "./types";
 
-type WalletConnectStoredKey = Omit<Key, "pubKey"> & { chainId?: string; pubKey: Key["pubKey"] | string };
+type WalletConnectAccount = {
+  address?: Key["address"] | number[] | string;
+  algo?: string;
+  bech32Address?: string;
+  chainId?: string;
+  isKeystone?: boolean;
+  isNanoLedger?: boolean;
+  name?: string;
+  pubKey?: Key["pubKey"] | string;
+  pubkey?: string;
+};
+
+type WalletConnectStoredKey = Key & { chainId?: string };
 
 export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   if (!useGrazInternalStore.getState().walletConnect?.options?.projectId?.trim()) {
@@ -106,11 +119,11 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     }
   };
 
-  const parseSessionKeys = (sessionProperties?: Record<string, string>): WalletConnectStoredKey[] | undefined => {
+  const parseSessionKeys = (sessionProperties?: Record<string, string>): WalletConnectAccount[] | undefined => {
     const rawKeys = sessionProperties?.keys;
     if (!rawKeys) return;
 
-    const keys = JSON.parse(String(rawKeys)) as WalletConnectStoredKey[];
+    const keys = JSON.parse(String(rawKeys)) as WalletConnectAccount[];
     if (!Array.isArray(keys) || keys.length === 0) throw new Error("No accounts");
 
     return keys;
@@ -118,6 +131,53 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
 
   const getWalletConnectChainId = (chainId?: string) =>
     chainId?.includes(":") ? parseChainId(chainId).reference : chainId;
+
+  const normalizeWalletConnectAccount = (
+    account: WalletConnectAccount,
+    fallbackChainId?: string,
+  ): WalletConnectStoredKey | undefined => {
+    const bech32Address = account.bech32Address ?? (typeof account.address === "string" ? account.address : undefined);
+    if (!account.algo || !bech32Address || (!account.pubKey && !account.pubkey)) return;
+
+    let address: Uint8Array | undefined;
+    let pubKey: Uint8Array;
+    if (account.address instanceof Uint8Array) {
+      address = account.address;
+    } else if (Array.isArray(account.address)) {
+      address = Uint8Array.from(account.address);
+    } else {
+      try {
+        address = fromBech32(bech32Address).data;
+      } catch {
+        return;
+      }
+    }
+
+    try {
+      if (account.pubkey) {
+        pubKey = fromBase64(account.pubkey);
+      } else if (typeof account.pubKey === "string") {
+        pubKey = Buffer.from(account.pubKey, encoding);
+      } else if (account.pubKey instanceof Uint8Array) {
+        pubKey = account.pubKey;
+      } else {
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    return {
+      address,
+      algo: account.algo,
+      bech32Address,
+      chainId: getWalletConnectChainId(account.chainId) ?? fallbackChainId,
+      isKeystone: account.isKeystone ?? false,
+      isNanoLedger: account.isNanoLedger ?? false,
+      name: account.name ?? "WalletConnect",
+      pubKey,
+    };
+  };
 
   const filterApprovedKeys = (
     resolvedSession: ResolvedSession,
@@ -155,14 +215,14 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
           },
         });
         const accounts = Array.isArray(response)
-          ? response
-          : (response as { accounts?: WalletConnectStoredKey[] }).accounts;
+          ? (response as WalletConnectAccount[])
+          : (response as { accounts?: WalletConnectAccount[] }).accounts;
         if (!Array.isArray(accounts) || accounts.length === 0) throw new Error("No accounts");
 
-        return accounts.map((account) => ({
-          ...account,
-          chainId: getWalletConnectChainId(account.chainId) || chainId,
-        })) as WalletConnectStoredKey[];
+        return accounts.flatMap((account) => {
+          const key = normalizeWalletConnectAccount(account, chainId);
+          return key ? [key] : [];
+        });
       }),
     );
 
@@ -177,7 +237,10 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     const storedKeys = filterApprovedKeys(
       resolvedSession,
       chainIds,
-      parseSessionKeys(resolvedSession.session.sessionProperties) ?? [],
+      (parseSessionKeys(resolvedSession.session.sessionProperties) ?? []).flatMap((account) => {
+        const key = normalizeWalletConnectAccount(account);
+        return key ? [key] : [];
+      }),
     );
     const missingChainIds = chainIds.filter((chainId) => !storedKeys.some((key) => key.chainId === chainId));
     if (missingChainIds.length === 0) return storedKeys;
@@ -203,7 +266,8 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     resolvedSession: ResolvedSession,
     requestedChainIds: string[],
   ) => {
-    const configuredChainIds = useGrazInternalStore.getState().chains?.map((chain) => chain.chainId) ?? requestedChainIds;
+    const configuredChainIds =
+      useGrazInternalStore.getState().chains?.map((chain) => chain.chainId) ?? requestedChainIds;
     const chainIds = resolveApprovedChainIds(resolvedSession.scope, requestedChainIds, configuredChainIds);
     if (chainIds.length === 0) throw new Error("No approved WalletConnect accounts for configured chains");
 
@@ -218,7 +282,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
         isNanoLedger: key.isNanoLedger,
         isKeystone: key.isKeystone,
         name: key.name,
-        pubKey: Buffer.from(String(key.pubKey), encoding),
+        pubKey: key.pubKey,
       };
     });
 
@@ -315,9 +379,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       const approving = async (signal: AbortSignal): Promise<SessionTypes.Struct> => {
         if (signal.aborted) return Promise.reject(new Error("User closed wallet connect"));
         return new Promise<SessionTypes.Struct>((resolve, reject) => {
-          approval()
-            .then(resolve)
-            .catch(reject);
+          approval().then(resolve).catch(reject);
           signal.addEventListener(
             "abort",
             () => {
@@ -383,7 +445,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
 
     return {
       ...key,
-      pubKey: Buffer.from(String(key.pubKey), encoding) as unknown as Uint8Array,
+      pubKey: key.pubKey,
     };
   };
 

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -3,16 +3,16 @@ import type { AccountData, Algo, DirectSignResponse } from "@cosmjs/proto-signin
 import type { Keplr } from "@keplr-wallet/types";
 import { WalletConnectModal } from "@walletconnect/modal";
 import { SignClient } from "@walletconnect/sign-client";
-import type { ISignClient, SignClientTypes } from "@walletconnect/types";
-import { getSdkError } from "@walletconnect/utils";
+import type { ISignClient, SessionTypes, SignClientTypes } from "@walletconnect/types";
+import { getSdkError, parseChainId } from "@walletconnect/utils";
 
 import { useGrazInternalStore, useGrazSessionStore } from "../../../store";
 import type { Key } from "../../../types/wallet";
 import { type SignAminoParams, type SignDirectParams, type Wallet, WalletType } from "../../../types/wallet";
 import { isAndroid, isIos, isMobile } from "../../../utils/os";
 import { promiseWithTimeout } from "../../../utils/timeout";
+import { type ResolvedSession, resolveSession } from "./approved-session";
 import type { GetWalletConnectParams, WalletConnectSignDirectResponse } from "./types";
-
 
 type WalletConnectStoredKey = Omit<Key, "pubKey"> & { chainId?: string; pubKey: Key["pubKey"] | string };
 
@@ -68,7 +68,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     await deleteInactivePairings(wcSignClient);
   };
 
-  const getSession = (chainId: string[]) => {
+  const getSession = (chainIds: string[]) => {
     try {
       const { wcSignClients } = useGrazSessionStore.getState();
       const wcSignClient = wcSignClients.get(walletType);
@@ -79,32 +79,13 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
 
       const isValid = lastSession.expiry * 1000 > Date.now() + 1000;
       if (!isValid) {
-        void wcDisconnect(lastSession.topic);
-        throw new Error("invalid session");
+        // An expired session may already be gone; don't block a fresh connection.
+        void wcDisconnect(lastSession.topic).catch(() => undefined);
       }
 
-      try {
-        const chainSession = allSession.find((x) => x.requiredNamespaces.cosmos?.chains?.includes(`cosmos:${chainId}`));
-        if (!chainSession) {
-          throw new Error("no session");
-        }
-        return chainSession;
-      } catch (error) {
-        if (!(error as Error).message.toLowerCase().includes("no matching key")) throw error;
-      }
-
-      return lastSession;
+      return resolveSession(lastSession, { chainIds });
     } catch (error) {
       if (!(error as Error).message.toLowerCase().includes("no matching key")) throw error;
-    }
-  };
-
-  const checkSession = (chainId: string[]) => {
-    try {
-      const lastSession = getSession(chainId);
-      return lastSession;
-    } catch (error) {
-      return undefined;
     }
   };
 
@@ -135,10 +116,31 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     return keys;
   };
 
-  const getWalletConnectChainId = (chainId?: string) => chainId?.split(":")[1] || chainId;
+  const getWalletConnectChainId = (chainId?: string) =>
+    chainId?.includes(":") ? parseChainId(chainId).reference : chainId;
+
+  const filterApprovedKeys = (
+    resolvedSession: ResolvedSession,
+    chainIds: readonly string[],
+    keys: WalletConnectStoredKey[],
+  ): WalletConnectStoredKey[] => {
+    const approvedAccounts = resolvedSession.scope.accounts.filter((account) => chainIds.includes(account.chainId));
+
+    return keys.flatMap((key) => {
+      const keyChainId = getWalletConnectChainId(key.chainId);
+      const matches = approvedAccounts.filter(
+        (account) => (!keyChainId || account.chainId === keyChainId) && account.address === key.bech32Address,
+      );
+      if (matches.length !== 1) return [];
+
+      const approvedAccount = matches[0];
+      return approvedAccount ? [{ ...key, chainId: approvedAccount.chainId }] : [];
+    });
+  };
 
   const requestAccounts = async (
     signClient: ISignClient,
+    resolvedSession: ResolvedSession,
     topic: string,
     chainIds: string[],
   ): Promise<WalletConnectStoredKey[]> => {
@@ -164,22 +166,78 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       }),
     );
 
-    return keysByChainId.flat();
+    return filterApprovedKeys(resolvedSession, chainIds, keysByChainId.flat());
   };
 
   const getSessionKeys = async (
     signClient: ISignClient,
-    session: { sessionProperties?: Record<string, string>; topic?: string },
+    resolvedSession: ResolvedSession,
     chainIds: string[],
   ): Promise<WalletConnectStoredKey[]> => {
-    const keys = parseSessionKeys(session.sessionProperties)?.map((key) => ({
-      ...key,
-      chainId: getWalletConnectChainId(key.chainId),
-    }));
-    if (keys?.some((key) => key.chainId && chainIds.includes(key.chainId))) return keys;
-    if (!session.topic) throw new Error("No wallet connect session");
+    const storedKeys = filterApprovedKeys(
+      resolvedSession,
+      chainIds,
+      parseSessionKeys(resolvedSession.session.sessionProperties) ?? [],
+    );
+    const missingChainIds = chainIds.filter((chainId) => !storedKeys.some((key) => key.chainId === chainId));
+    if (missingChainIds.length === 0) return storedKeys;
+    if (!resolvedSession.session.topic) throw new Error("No wallet connect session");
 
-    return requestAccounts(signClient, session.topic, chainIds);
+    const requestedKeys = await requestAccounts(
+      signClient,
+      resolvedSession,
+      resolvedSession.session.topic,
+      missingChainIds,
+    );
+    const keys = [...storedKeys, ...requestedKeys];
+    const unresolvedChainIds = chainIds.filter((chainId) => !keys.some((key) => key.chainId === chainId));
+    if (unresolvedChainIds.length > 0) {
+      throw new Error(`No WalletConnect accounts for approved chains: ${unresolvedChainIds.join(", ")}`);
+    }
+
+    return keys;
+  };
+
+  const getApprovedConfiguredChainIds = (resolvedSession: ResolvedSession, requestedChainIds: string[]) => {
+    const configuredChainIds = useGrazInternalStore.getState().chains?.map((chain) => chain.chainId) ?? requestedChainIds;
+    const approvedChainIds = new Set(resolvedSession.scope.chainIds);
+    const requested = requestedChainIds.filter(
+      (chainId) => approvedChainIds.has(chainId) && configuredChainIds.includes(chainId),
+    );
+    const additional = configuredChainIds.filter(
+      (chainId) => approvedChainIds.has(chainId) && !requested.includes(chainId),
+    );
+    return [...requested, ...additional];
+  };
+
+  const materializeAccounts = async (
+    signClient: ISignClient,
+    resolvedSession: ResolvedSession,
+    requestedChainIds: string[],
+  ) => {
+    const chainIds = getApprovedConfiguredChainIds(resolvedSession, requestedChainIds);
+    if (chainIds.length === 0) throw new Error("No approved WalletConnect accounts for configured chains");
+
+    const keys = await getSessionKeys(signClient, resolvedSession, chainIds);
+    const accounts: Record<string, Key> = {};
+    keys.forEach((key) => {
+      if (!key.chainId) return;
+      accounts[key.chainId] = {
+        address: key.address,
+        algo: key.algo as Algo,
+        bech32Address: key.bech32Address,
+        isNanoLedger: key.isNanoLedger,
+        isKeystone: key.isKeystone,
+        name: key.name,
+        pubKey: Buffer.from(String(key.pubKey), encoding),
+      };
+    });
+
+    useGrazSessionStore.setState((previous) => {
+      const nextAccounts = { ...(previous.accounts ?? {}) };
+      requestedChainIds.forEach((chainId) => delete nextAccounts[chainId]);
+      return { accounts: { ...nextAccounts, ...accounts } };
+    });
   };
 
   const init = async () => {
@@ -199,7 +257,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   const subscription: (reconnect: () => void) => () => void = (reconnect) => {
     const { wcSignClients } = useGrazSessionStore.getState();
     const wcSignClient = wcSignClients.get(walletType);
-     
+
     if (!wcSignClient) return () => {};
 
     const sessionEventListener = (args: SignClientTypes.EventArguments["session_event"]) => {
@@ -209,7 +267,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
         _accounts &&
         !Object.values(_accounts)
           .map((x) => x.bech32Address)
-           
+
           .includes(args.params.event.data[0])
       ) {
         const chainId = args.params.chainId.split(":")[1];
@@ -232,7 +290,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
 
   const enable = async (_chainId: string | string[]) => {
     const chainId = typeof _chainId === "string" ? [_chainId] : _chainId;
-    const { wcSignClients, activeChainIds } = useGrazSessionStore.getState();
+    const { wcSignClients } = useGrazSessionStore.getState();
     const signClient = wcSignClients.get(walletType);
     if (!signClient) throw new Error("enable walletConnect.signClient is not defined");
     const { walletConnect } = useGrazInternalStore.getState();
@@ -244,11 +302,11 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       enableExplorer: false,
       explorerRecommendedWalletIds: "NONE",
     });
-    const lastSession = checkSession(chainId);
-    if (!lastSession) {
+    const resolvedSession = getSession(chainId);
+    if (!resolvedSession) {
       const { uri, approval } = await promiseWithTimeout(
         signClient.connect({
-          requiredNamespaces: {
+          optionalNamespaces: {
             cosmos: {
               methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
               chains: chainId.map((i) => `cosmos:${i}`),
@@ -265,33 +323,11 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       } else {
         redirectToApp(uri);
       }
-      const approving = async (signal: AbortSignal) => {
+      const approving = async (signal: AbortSignal): Promise<SessionTypes.Struct> => {
         if (signal.aborted) return Promise.reject(new Error("User closed wallet connect"));
-        return new Promise((resolve, reject) => {
+        return new Promise<SessionTypes.Struct>((resolve, reject) => {
           approval()
-            .then(async (d) => {
-              const _acc = await getSessionKeys(signClient, d, chainId);
-              if (_acc.length === 0) return reject(new Error("No accounts"));
-              const acc = _acc[0];
-              if (!acc) return reject(new Error("No accounts"));
-              const resAcc: Record<string, Key> = {};
-              _acc.forEach((x) => {
-                if (!x.chainId) return;
-                resAcc[x.chainId] = {
-                  address: x.address,
-                  algo: x.algo as Algo,
-                  bech32Address: x.bech32Address,
-                  isNanoLedger: x.isNanoLedger,
-                  isKeystone: x.isKeystone,
-                  name: x.name,
-                  pubKey: Buffer.from(String(x.pubKey), encoding),
-                };
-              });
-              useGrazSessionStore.setState((prev) => ({
-                accounts: { ...(prev.accounts || {}), ...resAcc },
-              }));
-              return resolve(d);
-            })
+            .then(resolve)
             .catch(reject);
           signal.addEventListener(
             "abort",
@@ -303,6 +339,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
         });
       };
 
+      let approvedSession: SessionTypes.Struct | undefined;
       try {
         const controller = new AbortController();
         const signal = controller.signal;
@@ -311,35 +348,26 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
             controller.abort();
           }
         });
-        await approving(signal);
+        approvedSession = await approving(signal);
+        const approved = resolveSession(approvedSession);
+        if (!approved) throw new Error("No approved WalletConnect accounts");
+        await materializeAccounts(signClient, approved, chainId);
       } catch (error) {
         walletConnectModal.closeModal();
-        if (!(error as Error).message.toLowerCase().includes("no matching key")) return Promise.reject(error);
+        if (approvedSession?.topic) await wcDisconnect(approvedSession.topic).catch(() => undefined);
+        throw error;
       }
       if (!params) {
         walletConnectModal.closeModal();
       }
-      return Promise.resolve();
+      return;
     }
-    try {
-      await promiseWithTimeout(
-        (async () => {
-          const resultAcccounts = Object.fromEntries(
-            await Promise.all(
-              (activeChainIds || chainId).map(async (c): Promise<[string, Key]> => [c, await getKey(c)]),
-            ),
-          );
-          useGrazSessionStore.setState({
-            accounts: resultAcccounts,
-          });
-        })(),
-        15000,
-        new Error("Connection timeout"),
-      );
-    } catch (error) {
-      void wcDisconnect(lastSession.topic);
-      if (!(error as Error).message.toLowerCase().includes("no matching key")) throw error;
-    }
+
+    await promiseWithTimeout(
+      materializeAccounts(signClient, resolvedSession, chainId),
+      15000,
+      new Error("Connection timeout"),
+    );
   };
 
   const getAccount = async (chainId: string): Promise<AccountData> => {
@@ -353,13 +381,13 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   };
 
   const getKey = async (chainId: string): Promise<Key> => {
-    const session = getSession([chainId]);
-    if (!session?.topic) throw new Error("No wallet connect session");
+    const resolvedSession = getSession([chainId]);
+    if (!resolvedSession?.session.topic) throw new Error("No wallet connect session");
     const { wcSignClients } = useGrazSessionStore.getState();
     const wcSignClient = wcSignClients.get(walletType);
     if (!wcSignClient) throw new Error("walletConnect.signClient is not defined");
 
-    const keys = await getSessionKeys(wcSignClient, session, [chainId]);
+    const keys = await getSessionKeys(wcSignClient, resolvedSession, [chainId]);
     if (keys.length === 0) throw new Error("No wallet connect session");
     const key = keys.find((x) => x.chainId === chainId);
     if (!key) throw new Error(`No wallet connect key for chainId ${chainId}`);
@@ -377,7 +405,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     if (!wcSignClient) throw new Error("walletConnect.signClient is not defined");
     if (!account) throw new Error("account is not defined");
 
-    const topic = getSession([chainId])?.topic;
+    const topic = getSession([chainId])?.session.topic;
     if (!topic) throw new Error("No wallet connect session");
 
     if (!signDoc.bodyBytes) throw new Error("No bodyBytes");
@@ -426,7 +454,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     if (!wcSignClient) throw new Error("walletConnect.signClient is not defined");
     if (!account) throw new Error("account is not defined");
 
-    const topic = getSession([chainId])?.topic;
+    const topic = getSession([chainId])?.session.topic;
     if (!topic) throw new Error("No wallet connect session");
 
     redirectToApp();
@@ -493,10 +521,14 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       if (chainIds === undefined) {
         const sessions = signClient?.session.getAll();
         if (sessions !== undefined) await Promise.all(sessions.map((s) => wcDisconnect(s.topic)));
-      } else if (typeof chainIds === "string") {
-        await wcDisconnect(getSession([chainIds])?.topic);
       } else {
-        await Promise.all(chainIds.map((x) => wcDisconnect(getSession([x])?.topic)));
+        const requestedChainIds = typeof chainIds === "string" ? [chainIds] : chainIds;
+        const topics = new Set(
+          requestedChainIds
+            .map((chainId) => getSession([chainId])?.session.topic)
+            .filter((topic): topic is string => topic !== undefined),
+        );
+        await Promise.all([...topics].map(wcDisconnect));
       }
 
       // if no more sessions, remove signClient

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -479,7 +479,31 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       const isApproved = resolvedSession?.scope.accounts.some(
         (account) => account.chainId === chainId && account.address === storedKey.bech32Address,
       );
-      return isApproved ? storedKey : undefined;
+      if (!isApproved) return;
+      if (ArrayBuffer.isView(storedKey.address) && ArrayBuffer.isView(storedKey.pubKey)) return storedKey;
+
+      const restoreBytes = (value: Uint8Array): Uint8Array | undefined => {
+        if (value instanceof Uint8Array) return value;
+        if (!value || typeof value !== "object") return;
+
+        const entries = Object.entries(value);
+        const bytes = new Uint8Array(entries.length);
+        for (let index = 0; index < entries.length; index += 1) {
+          const byte = (value as unknown as Record<string, unknown>)[String(index)];
+          if (!Number.isInteger(byte) || Number(byte) < 0 || Number(byte) > 255) return;
+          bytes[index] = Number(byte);
+        }
+        return bytes;
+      };
+
+      const pubKey = restoreBytes(storedKey.pubKey);
+      if (!pubKey) return;
+
+      return {
+        ...storedKey,
+        address: fromBech32(storedKey.bech32Address).data,
+        pubKey,
+      };
     } catch (error) {
       if (!isMissingWalletConnectRecordError(error)) throw error;
     }

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -32,6 +32,15 @@ type WalletConnectStoredKey = Key & { chainId?: string };
 const disconnectingSessions = new WeakMap<ISignClient, Map<string, Promise<void>>>();
 const initializingSignClients = new Map<WalletType, Promise<ISignClient>>();
 
+const isMissingWalletConnectRecordError = (error: unknown) => {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return (
+    message.includes("no matching key") ||
+    message.includes("record was recently deleted") ||
+    message.includes("session topic does not exist in keychain")
+  );
+};
+
 export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
   if (!useGrazInternalStore.getState().walletConnect?.options?.projectId?.trim()) {
     throw new Error("walletConnect.options.projectId is not defined");
@@ -74,10 +83,14 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     if (pendingDisconnect) return pendingDisconnect;
 
     const disconnect = (async () => {
-      await wcSignClient.disconnect({
-        topic,
-        reason: getSdkError("USER_DISCONNECTED"),
-      });
+      try {
+        await wcSignClient.disconnect({
+          topic,
+          reason: getSdkError("USER_DISCONNECTED"),
+        });
+      } catch (error) {
+        if (!isMissingWalletConnectRecordError(error)) throw error;
+      }
       await deleteInactivePairings(wcSignClient);
     })();
     const trackedDisconnect = disconnect.finally(() => {
@@ -106,7 +119,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
 
       return resolveSession(lastSession, { chainIds });
     } catch (error) {
-      if (!(error as Error).message.toLowerCase().includes("no matching key")) throw error;
+      if (!isMissingWalletConnectRecordError(error)) throw error;
     }
   };
 
@@ -123,7 +136,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
         }),
       );
     } catch (error) {
-      if (!(error as Error).message.toLowerCase().includes("no matching key")) throw error;
+      if (!isMissingWalletConnectRecordError(error)) throw error;
     }
   };
 
@@ -274,7 +287,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     signClient: ISignClient,
     resolvedSession: ResolvedSession,
     requestedChainIds: string[],
-  ) => {
+  ): Promise<Record<string, Key>> => {
     const configuredChainIds =
       useGrazInternalStore.getState().chains?.map((chain) => chain.chainId) ?? requestedChainIds;
     const chainIds = resolveApprovedChainIds(resolvedSession.scope, requestedChainIds, configuredChainIds);
@@ -295,6 +308,10 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       };
     });
 
+    return accounts;
+  };
+
+  const commitAccounts = (accounts: Record<string, Key>, requestedChainIds: string[]) => {
     useGrazSessionStore.setState((previous) => {
       const nextAccounts = { ...(previous.accounts ?? {}) };
       requestedChainIds.forEach((chainId) => delete nextAccounts[chainId]);
@@ -429,7 +446,8 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
         approvedSession = await approving(signal);
         const approved = resolveSession(approvedSession);
         if (!approved) throw new Error("No approved WalletConnect accounts");
-        await materializeAccounts(signClient, approved, chainId);
+        const accounts = await materializeAccounts(signClient, approved, chainId);
+        commitAccounts(accounts, chainId);
       } catch (error) {
         walletConnectModal.closeModal();
         if (approvedSession?.topic) await wcDisconnect(approvedSession.topic).catch(() => undefined);
@@ -441,11 +459,12 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       return;
     }
 
-    await promiseWithTimeout(
+    const accounts = await promiseWithTimeout(
       materializeAccounts(signClient, resolvedSession, chainId),
       15000,
       new Error("Connection timeout"),
     );
+    commitAccounts(accounts, chainId);
   };
 
   const getAccount = async (chainId: string): Promise<AccountData> => {

--- a/packages/graz/src/actions/wallet/wallet-connect/index.ts
+++ b/packages/graz/src/actions/wallet/wallet-connect/index.ts
@@ -129,8 +129,11 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     return keys;
   };
 
-  const getWalletConnectChainId = (chainId?: string) =>
-    chainId?.includes(":") ? parseChainId(chainId).reference : chainId;
+  const getWalletConnectChainId = (chainId?: string) => {
+    if (!chainId?.includes(":")) return chainId;
+    const parsed = parseChainId(chainId);
+    return parsed.namespace === "cosmos" ? parsed.reference : undefined;
+  };
 
   const normalizeWalletConnectAccount = (
     account: WalletConnectAccount,
@@ -139,18 +142,15 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
     const bech32Address = account.bech32Address ?? (typeof account.address === "string" ? account.address : undefined);
     if (!account.algo || !bech32Address || (!account.pubKey && !account.pubkey)) return;
 
-    let address: Uint8Array | undefined;
+    const chainId = account.chainId === undefined ? fallbackChainId : getWalletConnectChainId(account.chainId);
+    if (account.chainId !== undefined && !chainId) return;
+
+    let address: Uint8Array;
     let pubKey: Uint8Array;
-    if (account.address instanceof Uint8Array) {
-      address = account.address;
-    } else if (Array.isArray(account.address)) {
-      address = Uint8Array.from(account.address);
-    } else {
-      try {
-        address = fromBech32(bech32Address).data;
-      } catch {
-        return;
-      }
+    try {
+      address = fromBech32(bech32Address).data;
+    } catch {
+      return;
     }
 
     try {
@@ -171,7 +171,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
       address,
       algo: account.algo,
       bech32Address,
-      chainId: getWalletConnectChainId(account.chainId) ?? fallbackChainId,
+      chainId,
       isKeystone: account.isKeystone ?? false,
       isNanoLedger: account.isNanoLedger ?? false,
       name: account.name ?? "WalletConnect",
@@ -188,6 +188,7 @@ export const getWalletConnect = (params?: GetWalletConnectParams): Wallet => {
 
     return keys.flatMap((key) => {
       const keyChainId = getWalletConnectChainId(key.chainId);
+      if (key.chainId !== undefined && !keyChainId) return [];
       const matches = approvedAccounts.filter(
         (account) => (!keyChainId || account.chainId === keyChainId) && account.address === key.bech32Address,
       );

--- a/packages/graz/src/provider/__tests__/provider-events.test.tsx
+++ b/packages/graz/src/provider/__tests__/provider-events.test.tsx
@@ -286,7 +286,7 @@ describe("provider components and events", () => {
   it.each([
     ["session_delete", "wallet"],
     ["session_expire", "session-expired"],
-  ] as const)("normalizes WalletConnect account and %s events", async (sessionEvent, disconnectReason) => {
+  ] as const)("handles WalletConnect %s events for a chain-scoped optional session", async (sessionEvent, disconnectReason) => {
     const chain = makeChainInfo();
     const previousAccount = {
       ...makeKey(chain.chainId),
@@ -295,6 +295,8 @@ describe("provider components and events", () => {
     };
     const listeners = new Map<string, Set<(args?: unknown) => void>>();
     let bech32Address = makeBech32Address(2);
+    let activeSessionExpiry = Math.floor(Date.now() / 1000) + 60;
+    let includeActiveSession = true;
     const signClient = {
       events: {
         emit: (event: string, args?: unknown) => {
@@ -328,19 +330,15 @@ describe("provider components and events", () => {
             topic: "unrelated-topic",
           },
           {
-            expiry: Math.floor(Date.now() / 1000) + 60,
+            expiry: activeSessionExpiry,
             namespaces: {
-              cosmos: {
+              [`cosmos:${chain.chainId}`]: {
                 accounts: [`cosmos:${chain.chainId}:${bech32Address}`],
                 events: ["chainChanged", "accountsChanged"],
                 methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
               },
             },
-            requiredNamespaces: {
-              cosmos: {
-                chains: [`cosmos:${chain.chainId}`],
-              },
-            },
+            requiredNamespaces: {},
             sessionProperties: {
               keys: JSON.stringify([
                 {
@@ -354,7 +352,7 @@ describe("provider components and events", () => {
             },
             topic: "topic-1",
           },
-        ]),
+        ].filter((session) => includeActiveSession || session.topic !== "topic-1")),
       },
     };
     const wcSignClients = new Map<WalletType, ISignClient>([
@@ -454,6 +452,8 @@ describe("provider components and events", () => {
     });
     expect(onDisconnect).not.toHaveBeenCalled();
 
+    if (sessionEvent === "session_expire") activeSessionExpiry = Math.floor(Date.now() / 1000) - 1;
+    includeActiveSession = false;
     await act(async () => {
       signClient.events.emit(
         sessionEvent,
@@ -471,6 +471,7 @@ describe("provider components and events", () => {
       activeChainIds: null,
       status: "disconnected",
     });
+    expect(useGrazSessionStore.getState().wcSignClients.get(WalletType.WALLETCONNECT)).toBe(signClient);
     rendered.unmount();
     expect(signClient.events.off).toHaveBeenCalledWith("session_event", expect.any(Function));
   });

--- a/packages/graz/src/provider/__tests__/provider-events.test.tsx
+++ b/packages/graz/src/provider/__tests__/provider-events.test.tsx
@@ -3,6 +3,7 @@ import { toBech32 } from "@cosmjs/encoding";
 import type { ISignClient } from "@walletconnect/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { reconnect } from "../../actions/account";
 import { subscribeWalletEvents } from "../../actions/events";
 import { makeChainInfo } from "../../__tests__/fixtures";
 import { flushReact, renderComponent } from "../../__tests__/react";
@@ -284,9 +285,11 @@ describe("provider components and events", () => {
   });
 
   it.each([
-    ["session_delete", "wallet"],
-    ["session_expire", "session-expired"],
-  ] as const)("handles WalletConnect %s events for a chain-scoped optional session", async (sessionEvent, disconnectReason) => {
+    ["session_delete", "wallet", false],
+    ["session_expire", "session-expired", false],
+    ["session_delete", "wallet", true],
+    ["session_expire", "session-expired", true],
+  ] as const)("handles WalletConnect %s (%s) for a chain-scoped optional session (replaced: %s)", async (sessionEvent, disconnectReason, replaceSession) => {
     const chain = makeChainInfo();
     const previousAccount = {
       ...makeKey(chain.chainId),
@@ -297,6 +300,7 @@ describe("provider components and events", () => {
     let bech32Address = makeBech32Address(2);
     let activeSessionExpiry = Math.floor(Date.now() / 1000) + 60;
     let includeActiveSession = true;
+    let activeSessionTopic = "topic-1";
     const signClient = {
       events: {
         emit: (event: string, args?: unknown) => {
@@ -350,9 +354,9 @@ describe("provider components and events", () => {
                 },
               ]),
             },
-            topic: "topic-1",
+            topic: activeSessionTopic,
           },
-        ].filter((session) => includeActiveSession || session.topic !== "topic-1")),
+        ].filter((session) => includeActiveSession || session.topic !== activeSessionTopic)),
       },
     };
     const wcSignClients = new Map<WalletType, ISignClient>([
@@ -383,6 +387,35 @@ describe("provider components and events", () => {
     const rendered = renderComponent(<GrazEvents />);
     await flushReact();
 
+    if (replaceSession) {
+      await act(async () => {
+        // The SDK replaces the session while Graz retains the client and connector.
+        activeSessionTopic = "topic-2";
+        bech32Address = previousAccount.bech32Address;
+        await reconnect();
+      });
+      expect(useGrazSessionStore.getState().wcSignClients).toBe(wcSignClients);
+      expect(useGrazInternalStore.getState()._reconnectConnector).toBe(WalletType.WALLETCONNECT);
+      expect(onAccountChange).not.toHaveBeenCalled();
+      bech32Address = makeBech32Address(2);
+
+      await act(async () => {
+        signClient.events.emit("session_event", {
+          id: 0,
+          params: {
+            chainId: `cosmos:${chain.chainId}`,
+            event: { data: [bech32Address], name: "accountsChanged" },
+          },
+          topic: "topic-1",
+        });
+        signClient.events.emit(sessionEvent, { id: 0, topic: "topic-1" });
+        await Promise.resolve();
+      });
+      expect(onAccountChange).not.toHaveBeenCalled();
+      expect(onDisconnect).not.toHaveBeenCalled();
+      expect(useGrazSessionStore.getState().status).toBe("connected");
+    }
+
     await act(async () => {
       signClient.events.emit("session_event", {
         id: 1,
@@ -409,7 +442,7 @@ describe("provider components and events", () => {
             name: "accountsChanged",
           },
         },
-        topic: "topic-1",
+        topic: activeSessionTopic,
       });
       await Promise.resolve();
     });
@@ -435,7 +468,7 @@ describe("provider components and events", () => {
             name: "chainChanged",
           },
         },
-        topic: "topic-1",
+        topic: activeSessionTopic,
       });
       await Promise.resolve();
     });
@@ -457,7 +490,7 @@ describe("provider components and events", () => {
     await act(async () => {
       signClient.events.emit(
         sessionEvent,
-        sessionEvent === "session_delete" ? { id: 5, topic: "topic-1" } : { topic: "topic-1" },
+        sessionEvent === "session_delete" ? { id: 5, topic: activeSessionTopic } : { topic: activeSessionTopic },
       );
       await Promise.resolve();
     });

--- a/packages/graz/src/provider/__tests__/provider-events.test.tsx
+++ b/packages/graz/src/provider/__tests__/provider-events.test.tsx
@@ -305,6 +305,13 @@ describe("provider components and events", () => {
         getAll: vi.fn(() => [
           {
             expiry: Math.floor(Date.now() / 1000) + 60,
+            namespaces: {
+              cosmos: {
+                accounts: ["cosmos:osmosis-1:osmo1unrelated"],
+                events: ["chainChanged", "accountsChanged"],
+                methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
+              },
+            },
             requiredNamespaces: {
               cosmos: {
                 chains: ["cosmos:osmosis-1"],
@@ -314,6 +321,13 @@ describe("provider components and events", () => {
           },
           {
             expiry: Math.floor(Date.now() / 1000) + 60,
+            namespaces: {
+              cosmos: {
+                accounts: [`cosmos:${chain.chainId}:${bech32Address}`],
+                events: ["chainChanged", "accountsChanged"],
+                methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
+              },
+            },
             requiredNamespaces: {
               cosmos: {
                 chains: [`cosmos:${chain.chainId}`],

--- a/packages/graz/src/provider/__tests__/provider-events.test.tsx
+++ b/packages/graz/src/provider/__tests__/provider-events.test.tsx
@@ -1,4 +1,5 @@
 import { act } from "react";
+import { toBech32 } from "@cosmjs/encoding";
 import type { ISignClient } from "@walletconnect/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,6 +13,9 @@ import { WalletType } from "../../types/wallet";
 import { ClientOnly } from "../client-only";
 import { GrazEvents } from "../events";
 import { GrazProvider } from "../index";
+
+const makeAddress = (value: number) => new Uint8Array(20).fill(value);
+const makeBech32Address = (value: number) => toBech32("cosmos", makeAddress(value));
 
 const makeKey = (chainId: string): Key => ({
   address: new Uint8Array([1, 2, 3]),
@@ -284,9 +288,13 @@ describe("provider components and events", () => {
     ["session_expire", "session-expired"],
   ] as const)("normalizes WalletConnect account and %s events", async (sessionEvent, disconnectReason) => {
     const chain = makeChainInfo();
-    const previousAccount = makeKey(chain.chainId);
+    const previousAccount = {
+      ...makeKey(chain.chainId),
+      address: makeAddress(1),
+      bech32Address: makeBech32Address(1),
+    };
     const listeners = new Map<string, Set<(args?: unknown) => void>>();
-    let bech32Address = `${chain.chainId}1changed`;
+    let bech32Address = makeBech32Address(2);
     const signClient = {
       events: {
         emit: (event: string, args?: unknown) => {
@@ -307,7 +315,7 @@ describe("provider components and events", () => {
             expiry: Math.floor(Date.now() / 1000) + 60,
             namespaces: {
               cosmos: {
-                accounts: ["cosmos:osmosis-1:osmo1unrelated"],
+                accounts: [`cosmos:osmosis-1:${makeBech32Address(4)}`],
                 events: ["chainChanged", "accountsChanged"],
                 methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
               },
@@ -418,7 +426,7 @@ describe("provider components and events", () => {
     expect(useGrazInternalStore.getState().walletType).toBe(WalletType.WALLETCONNECT);
     expect(window.sessionStorage.getItem(RECONNECT_SESSION_KEY)).toBe("Active");
 
-    bech32Address = `${chain.chainId}1ignored`;
+    bech32Address = makeBech32Address(3);
     await act(async () => {
       signClient.events.emit("session_event", {
         id: 3,

--- a/packages/graz/src/provider/events.tsx
+++ b/packages/graz/src/provider/events.tsx
@@ -154,9 +154,6 @@ export const useGrazEvents = () => {
       };
       const handleDisconnect = (topic: string, reason: "wallet" | "session-expired") => {
         if (!isActiveSessionTopic(topic)) return;
-        const clients = new Map(useGrazSessionStore.getState().wcSignClients);
-        clients.delete(_reconnectConnector);
-        useGrazSessionStore.setState({ wcSignClients: clients });
         void disconnectWithReason(reason);
       };
       const handleSessionDelete = (args: SignClientTypes.EventArguments["session_delete"]) => {

--- a/packages/graz/src/provider/events.tsx
+++ b/packages/graz/src/provider/events.tsx
@@ -174,7 +174,7 @@ export const useGrazEvents = () => {
       void reconnect({ onError: _onReconnectFailed });
     });
 
-  }, [_onReconnectFailed, _reconnectConnector, isReconnectConnectorReady, logger, wcSignClients]);
+  }, [_onReconnectFailed, _reconnectConnector, activeChains, isReconnectConnectorReady, logger, wcSignClients]);
 
   return null;
 };

--- a/packages/graz/src/provider/events.tsx
+++ b/packages/graz/src/provider/events.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 
 import { connect, disconnectWithReason, reconnect } from "../actions/account";
 import { checkWallet, getWallet, isWalletConnect } from "../actions/wallet";
+import { resolveSessionScope } from "../actions/wallet/wallet-connect/approved-session";
 import { LogCategory } from "../types/logger";
 import { getLogger } from "../utils/logger";
 import { RECONNECT_SESSION_KEY } from "../constant";
@@ -124,29 +125,19 @@ export const useGrazEvents = () => {
       const signClient = wcSignClients.get(_reconnectConnector);
       if (!signClient) return;
 
-      const isActiveSessionTopic = (topic: string): boolean => {
-        const { activeChainIds } = useGrazSessionStore.getState();
-        const { recentChainIds } = useGrazInternalStore.getState();
-        const connectedChainIds = activeChainIds || recentChainIds || [];
-        const sessions = signClient.session.getAll();
-        const activeSession =
-          connectedChainIds.length > 0
-            ? [...sessions].reverse().find((session) => {
-                const namespace = session.namespaces?.cosmos;
-                const sessionChainIds = [
-                  ...(session.requiredNamespaces.cosmos?.chains || []),
-                  ...(namespace?.chains || []),
-                  ...(namespace?.accounts || []).map((account) =>
-                    account.split(":").slice(0, 2).join(":"),
-                  ),
-                ].map((chainId) => chainId.split(":")[1]);
-
-                return connectedChainIds.some((chainId) => sessionChainIds.includes(chainId));
-              })
-            : sessions.at(-1);
-
-        return activeSession?.topic === topic;
-      };
+      const { activeChainIds } = useGrazSessionStore.getState();
+      const { recentChainIds } = useGrazInternalStore.getState();
+      const connectedChainIds = activeChainIds || recentChainIds || [];
+      const sessions = signClient.session.getAll();
+      const activeSession =
+        connectedChainIds.length > 0
+          ? [...sessions].reverse().find((session) => {
+              const scope = resolveSessionScope(session.namespaces);
+              return scope && connectedChainIds.some((chainId) => scope.chainIds.includes(chainId));
+            })
+          : sessions.at(-1);
+      const activeSessionTopic = activeSession?.topic;
+      const isActiveSessionTopic = (topic: string): boolean => activeSessionTopic === topic;
       const handleSessionEvent = (args: SignClientTypes.EventArguments["session_event"]) => {
         if (!isActiveSessionTopic(args.topic)) return;
         if (args.params.event.name !== "accountsChanged") return;


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

WalletConnect wallets may approve only some of the optional Cosmos chains requested by Graz. Continuing with the requested chain list can reject an otherwise valid connection or leave connected-chain state inconsistent with the available accounts.

This PR uses the approved session namespace as the source of truth. Connections use the approved chains configured in `GrazProvider`, and the same approved account identity is respected when preparing offline signers and handling session lifecycle events. Public TypeScript signatures remain unchanged, but successful WalletConnect connections may omit requested chains. Applications must check the returned `accounts[chainId]` for each chain required by their operation before proceeding.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

### Approved connection scope

- Propose Cosmos chains through `optionalNamespaces`.
- Resolve usable chains from approved session accounts and provider configuration, preserving requested order before additional configured chains.
- Reflect that scope in accounts, active/recent chains, connection results, events, and logs.

### Account compatibility and offline signing

- Support standard Cosmos account responses alongside existing Keplr-style responses; `sessionProperties.keys` remains an optional fast path.
- Normalize account data before matching approved chain/address pairs, requesting only missing approved keys.
- Reuse materialized keys for offline signing only when they match the latest valid session; fall back to account requests when keys are missing or mismatched.
- Restore persisted public-key bytes before exposing offline signer accounts.

### Session lifecycle and failure handling

- Handle deletion and expiry for both generic and chain-scoped Cosmos namespaces.
- Commit account state only after materialization succeeds, so RPC results arriving after a timeout cannot overwrite existing accounts.
- Clean up failed fresh sessions while preserving reused sessions and accounts when materialization fails.
- Preserve SignClient instances across session cleanup, coalesce concurrent initialization/disconnect operations, and tolerate already-removed records without hiding other disconnect failures.

## Screenshots

N/A

## Testing

- [x] `pnpm graz test`
- [x] `pnpm graz build`
- [x] `pnpm graz type-check`

## Links/References

- [WalletConnect Wallet SDK: session approval and namespaces](https://docs.walletconnect.network/wallet-sdk/web/usage#session-approval)

## Notes

- Session resolution retains the latest-session-only policy.
- Omitted optional chains are valid partial approval; approved configured chains must still provide usable account metadata.
- Per-chain method and event authorization changes are outside this PR.

also fixes #281
